### PR TITLE
Applies style guide to state tax pages

### DIFF
--- a/_includes/components/billedaccount.njk
+++ b/_includes/components/billedaccount.njk
@@ -4,14 +4,14 @@
   <p><b>Centrally billed accounts (CBA):</b> Accounts are issued at the agency, bureau, division, or fleet level, rather than to individuals (even if an individual’s name is on the card).  The federal government is billed directly for the purchase of goods and services and should not be assessed sales or use tax. These include:</p>
     <ul>
       <li>Purchase cards</li>
-      <li>CBA Travel cards</li>
+      <li>CBA Travel Cards</li>
       <li>Fleet cards</li>
       <li>Integrated cards</li>
-      <li>Tax Advantage Travel cards</li>
+      <li>Tax Advantage Travel Cards</li>
     </ul>
   </li>
   <li><p><b>Individually billed accounts (IBA):</b>
-    Accounts are issued to authorized federal government employees. Transactions may include travel expenses, which are paid by the employee directly and are later reimbursed by the federal government.  This applies to IBA travel cards.
+    Accounts are issued to authorized federal government employees. Transactions may include travel expenses, which are paid by the employee directly and are later reimbursed by the federal government.  This applies to IBA Travel Cards.
     </p>
   </li>
 </ul>

--- a/_includes/layouts/state-tax.njk
+++ b/_includes/layouts/state-tax.njk
@@ -4,7 +4,7 @@ date: git Last Modified
 tags: state-tax-information
 hideTitle: true
 eleventyComputed:
-  title: "{{ name }} tax information"
+  title: "{{ name }} Tax Information"
   permalink: "/smarttax/state-tax-information/{{ name | slug }}/"
 ---
 
@@ -46,7 +46,7 @@ eleventyComputed:
 
 {{ content | safe }}
 
-<h2>State point of contact</h2>
+<h2>Point of Contact</h2>
 <div>
   <a href="{{ contact.link }}">{{ contact.name }}</a>
 </div>

--- a/pages/smarttax/state-tax-information/alabama.md
+++ b/pages/smarttax/state-tax-information/alabama.md
@@ -12,6 +12,6 @@ contact:
   phone: 334-242-1490
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [What is the latest FEDERAL CREDIT CARD PROGRAM GSA SmartPay® 3 Information?](https://www.revenue.alabama.gov/faqs/what-is-the-latest-federal-credit-card-program-gsa-smartpay-3-information/)

--- a/pages/smarttax/state-tax-information/alaska.md
+++ b/pages/smarttax/state-tax-information/alaska.md
@@ -11,9 +11,9 @@ contact:
   phone: 907-269-6620
 ---
 
-## Required forms
+## Forms
 
-### Travel card
+### Travel Card
 
 * [Form 631 Vehicle Rental Tax Government Use Exemption Certificate](http://www.tax.alaska.gov/programs/programs/forms/index.aspx?60255)
 
@@ -21,7 +21,7 @@ contact:
 
 Alaska imposes a separate excise tax on rental vehicles. Government employees are exempt from this tax.
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Vehicle Rental Tax Exemption FAQs](https://tax.alaska.gov/programs/programs/help/faq/faq.aspx?60255#section2)
 

--- a/pages/smarttax/state-tax-information/arizona.md
+++ b/pages/smarttax/state-tax-information/arizona.md
@@ -14,9 +14,9 @@ contact:
   phone: 602-255-3381
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Transaction Privilege Tax Exemption Certificate](https://azdor.gov/forms/tpt-forms/tpt-exemption-certificate-general)
 
@@ -32,6 +32,6 @@ Notes for the transaction privilege tax:
 * Should the merchant choose not to request an exemption, the state allows the transaction privilege tax to be passed along from the merchant to the cardholder.
 * This is allowable, as the transaction privilege tax is not a state sales tax.
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Transaction Privilege Tax Exemptions](https://azdor.gov/transaction-privilege-tax/tpt-exemptions)

--- a/pages/smarttax/state-tax-information/arkansas.md
+++ b/pages/smarttax/state-tax-information/arkansas.md
@@ -12,6 +12,6 @@ contact:
   phone: 501-682-7104
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Agency 006.05 Arkansas Rules](https://www.dfa.arkansas.gov/images/uploads/revenuePolicyLegalOffice/et2008_3.pdf) - See GR-47. Exemptions from Tax – Sales to the United States Government and GR-47.1 Exemptions from Tax – Federal Credit Card Purchases (p. 87)

--- a/pages/smarttax/state-tax-information/california.md
+++ b/pages/smarttax/state-tax-information/california.md
@@ -12,6 +12,6 @@ contact:
   phone: 800-400-7115
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Publication 102, Sales to the United States Government](https://www.cdtfa.ca.gov/formspubs/pub102/#bankcards)

--- a/pages/smarttax/state-tax-information/colorado.md
+++ b/pages/smarttax/state-tax-information/colorado.md
@@ -12,19 +12,19 @@ contact:
   phone: 303-238-7378
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
-
-* [DR 1367 Affidavit Of Sales Paid By Government Credit Card](https://tax.colorado.gov/sales-use-tax-forms)
-* [DR 5002 Standard Colorado Affidavit of Exempt Sale](https://tax.colorado.gov/sales-use-tax-forms)
-
-### Travel card
+### Purchase Card
 
 * [DR 1367 Affidavit Of Sales Paid By Government Credit Card](https://tax.colorado.gov/sales-use-tax-forms)
 * [DR 5002 Standard Colorado Affidavit of Exempt Sale](https://tax.colorado.gov/sales-use-tax-forms)
 
-## State laws, regulations, policies
+### Travel Card
+
+* [DR 1367 Affidavit Of Sales Paid By Government Credit Card](https://tax.colorado.gov/sales-use-tax-forms)
+* [DR 5002 Standard Colorado Affidavit of Exempt Sale](https://tax.colorado.gov/sales-use-tax-forms)
+
+## Laws, Regulations, Policies
 
 * [Tax Exemption Qualifications](https://tax.colorado.gov/tax-exemption-qualifications)
 * [FYI Sales 63 Government Purchases Exemptions](https://tax.colorado.gov/sites/tax/files/Sales63.pdf)

--- a/pages/smarttax/state-tax-information/connecticut.md
+++ b/pages/smarttax/state-tax-information/connecticut.md
@@ -12,9 +12,9 @@ contact:
   phone: 860-297-5962
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [CERT - 134 Connecticut Exempt Purchases by Qualifying Government Agencies](https://portal.ct.gov/DRS/Sales-Tax/Exemption-Certificates) <span class="usa-tag">Optional</span>
 

--- a/pages/smarttax/state-tax-information/delaware.md
+++ b/pages/smarttax/state-tax-information/delaware.md
@@ -4,7 +4,7 @@ layout: layouts/state-tax
 name: Delaware
 exceptionsApply: true
 summary:
-  - The state does not have a sales tax, instead it imposes an occupancy tax for hotel stay.
+  - The state does not have a sales tax; instead it imposes an occupancy tax for hotel stay.
   - The federal government is exempt from occupancy tax.
 contact:
   name: Delaware Division of Revenue
@@ -12,8 +12,8 @@ contact:
   phone: 302-577-8205
 ---
 
-## Required forms
+## Forms
 
-### Travel card
+### Travel Card
 
 * [Form 6100: Exemption Certificate from Tax on Occupancy of Hotel, Motel and Tourist Home Rooms](https://revenuefiles.delaware.gov/docs/6100.pdf)

--- a/pages/smarttax/state-tax-information/district-of-columbia.md
+++ b/pages/smarttax/state-tax-information/district-of-columbia.md
@@ -12,7 +12,7 @@ contact:
   phone: 202-727-4829
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [OTR's Position for Sales Tax Concerning Hotels](https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/tax_guide_hotels.pdf)
 * [OTR Notice 2019-08 District of Columbia Sales Tax Exemption Payment Policy for Federal Government and District of Columbia Agencies](https://otr.cfo.dc.gov/sites/default/files/dc/sites/otr/publication/attachments/GSA_Notice.pdf)

--- a/pages/smarttax/state-tax-information/florida.md
+++ b/pages/smarttax/state-tax-information/florida.md
@@ -12,9 +12,9 @@ contact:
   phone: 850-488-6800
 ---
 
-## Required forms
+## Forms
 
-### Travel card
+### Travel Card
 
 #### Notes
 
@@ -22,7 +22,7 @@ According to the State of Florida, a Certificate of Exemption is not required fo
 
 As a Certificate of Exemption is not required for federal government agencies or employees, federal government agencies or employees may not have a Certificate of Exemption.  However, the state does allow merchants to request a Certificate of Exemption for their records.  Should a merchant require a Certificate of Exemption, please see Florida Administrative Code Rule below for information and language about the Certificate of Exemption for federal government agencies and employees.
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Sales Tax Exemption Certificates for Government Entities](https://floridarevenue.com/taxes/businesses/Pages/sales_cex.aspx)
 * [Florida Administrative Code Rule 12A-1.038(4)(c)](https://www.flrules.org/gateway/ruleNo.asp?id=12A-1.038) - Applicable language on page 4

--- a/pages/smarttax/state-tax-information/georgia.md
+++ b/pages/smarttax/state-tax-information/georgia.md
@@ -12,9 +12,9 @@ contact:
   phone: 404-417-6649
 ---
 
-## Required forms
+## Forms
 
-### Travel card
+### Travel Card
 
 * [State of Georgia Certificate of Exemption of Local Hotel/Motel Excise Tax](https://sao.georgia.gov/search?search=sog%20hotel%20tax%20exempt&sm_site_name=sao)
 
@@ -22,6 +22,6 @@ contact:
 
 A $5.00 hotel-motel fee is imposed for each calendar night a hotel or motel room is rented in Georgia.  This fee does not apply to hotel rooms rented by the federal government when a centrally billed card is the form of payment.
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Rule 560-13-2-.01 State Hotel-Motel Fee](https://rules.sos.ga.gov/gac/560-13-2)

--- a/pages/smarttax/state-tax-information/hawaii.md
+++ b/pages/smarttax/state-tax-information/hawaii.md
@@ -4,7 +4,7 @@ layout: layouts/state-tax
 name: Hawaii
 exceptionsApply: true
 summary:
-  - The state does not have a sales tax, instead it assesses a General Excise Tax (GET) and a Transient Accomodation Tax (TAT) on merchants.
+  - The state does not have a sales tax; instead it assesses a General Excise Tax (GET) and a Transient Accomodation Tax (TAT) on merchants.
   - Individually billed accounts (IBA) are not exempt from GET or TAT.
   - Centrally billed accounts (CBA) may be exempt from GET.
 contact:
@@ -13,9 +13,9 @@ contact:
   phone: 808-587-1577
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 #### Notes
 
@@ -27,7 +27,7 @@ Notes for the GET:
 * If a business sells goods to the federal government, the sale is exempt and the business may claim a deduction.
 * Should the vendor not claim a deduction, the assessment of GET is allowable as it is not a state sales tax.
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Tax Facts 37-1 General Excise Tax](https://tax.hawaii.gov/legal/a2_b2_1taxfacts/)
 * [An Introduction to the Transient Accommodations Tax](https://files.hawaii.gov/tax/legal/brochures/TAT_brochure.pdf)

--- a/pages/smarttax/state-tax-information/idaho.md
+++ b/pages/smarttax/state-tax-information/idaho.md
@@ -12,12 +12,12 @@ contact:
   phone: 800-972-7660
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Form ST-101 Sales Tax Resale or Exemption Certificate](https://tax.idaho.gov/taxes/sales-use/sales-tax/retailers/general/resale/)
 
-### CBA Travel card
+### CBA Travel Card
 
 * [Form ST-104HM Tax Exemption on Lodging Accommodations](https://tax.idaho.gov/taxes/sales-use/forms/)

--- a/pages/smarttax/state-tax-information/illinois.md
+++ b/pages/smarttax/state-tax-information/illinois.md
@@ -10,9 +10,9 @@ contact:
   phone: 800-732-8866
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Form CRT 61 Certificate of Resale](https://tax.illinois.gov/forms/sales/salesandusetax.html)
 
@@ -20,7 +20,7 @@ contact:
 
 The state requires an e-number for tax exemption. To receive an e-number, please apply using [the STAX-1 application](https://tax.illinois.gov/forms/reg/stax-1.html).
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Sales and Use Tax Exemptions](https://tax.illinois.gov/research/taxinformation/sales/rot.html)
 * [PIO-37 Information for exclusively charitable, religious, or educational organizations; governmental bodies; and certain other tax-exempt organizations](https://tax.illinois.gov/research/publications/pio-37.html)

--- a/pages/smarttax/state-tax-information/index.njk
+++ b/pages/smarttax/state-tax-information/index.njk
@@ -1,5 +1,5 @@
 ---
-title: State tax information
+title: State Tax Information
 layout: layouts/smarttax
 permalink: /smarttax/state-tax-information/
 tags: smarttax

--- a/pages/smarttax/state-tax-information/indiana.md
+++ b/pages/smarttax/state-tax-information/indiana.md
@@ -12,8 +12,8 @@ contact:
   phone: 317-232-2240
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [General Sales Tax Exemption Certificate](https://www.in.gov/dor/tax-forms/sales-tax-forms/)

--- a/pages/smarttax/state-tax-information/iowa.md
+++ b/pages/smarttax/state-tax-information/iowa.md
@@ -12,8 +12,8 @@ contact:
   phone: 515-281-3114
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Iowa Sales/Use/Excise Tax Exemption Certificate 31-014](https://tax.iowa.gov/forms/iowa-salesuseexcise-tax-exemption-certificate-31-014)

--- a/pages/smarttax/state-tax-information/kansas.md
+++ b/pages/smarttax/state-tax-information/kansas.md
@@ -12,16 +12,16 @@ contact:
   phone: 785-368-8222
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Form ST-28G U.S. Government, Federal Agency or Instrumentality Exemption Certificate](https://www.ksrevenue.gov/pdf/st28g.pdf)
 
-### Travel card
+### Travel Card
 
 * [Form ST-28H Sales and/or Transient Guest Tax Exemption Certificate for Lodging](https://www.ksrevenue.gov/pdf/st28h.pdf)
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Tax Entity Exemption Certificates](https://www.ksrevenue.gov/prpecentitylearnmore.html)

--- a/pages/smarttax/state-tax-information/kentucky.md
+++ b/pages/smarttax/state-tax-information/kentucky.md
@@ -18,8 +18,6 @@ contact:
 
 * [Purchase Exemption Certificate](https://revenue.ky.gov/Business/Sales-Use-Tax/Pages/default.aspx) - Form 51A126 (12-09) Purchase Exemption Certificate
 
-#### Notes
-
 ## Laws, Regulations, Policies
 
 * [103 KAR 30:235. Sales to the Federal Government](https://apps.legislature.ky.gov/law/kar/titles/103/030/235/)

--- a/pages/smarttax/state-tax-information/kentucky.md
+++ b/pages/smarttax/state-tax-information/kentucky.md
@@ -12,14 +12,14 @@ contact:
   phone: 502-564-4581​
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Purchase Exemption Certificate](https://revenue.ky.gov/Business/Sales-Use-Tax/Pages/default.aspx) - Form 51A126 (12-09) Purchase Exemption Certificate
 
 #### Notes
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [103 KAR 30:235. Sales to the Federal Government](https://apps.legislature.ky.gov/law/kar/titles/103/030/235/)

--- a/pages/smarttax/state-tax-information/louisiana.md
+++ b/pages/smarttax/state-tax-information/louisiana.md
@@ -12,18 +12,18 @@ contact:
   phone: 225-219-7462
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Form R-1304 Sales Tax Exemption for Certain Purchases and Leases for the Federal Government or the U.S. Department of Navy](https://revenue.louisiana.gov/Forms/ForBusinesses)
 * [Form R-1356-L Sales Tax Exemption for Purchases by the Federal Government](https://revenue.louisiana.gov/Forms/ForBusinesses)
 
-### Travel card
+### Travel Card
 
 * [R-1376 Government Employees Hotel Lodging Sales/Use Tax Exemption Certificate](https://revenue.louisiana.gov/Forms/ForBusinesses)
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Revenue Ruling No. 07-008 Sales Tax Federal Credit Card Purchases](https://revenue.louisiana.gov/LawsPolicies/RR07008.pdf)
 * [Revenue Information Bulletin No. 10-012 Sales Tax](https://www.revenue.louisiana.gov/LawsPolicies/RIB10012.pdf)

--- a/pages/smarttax/state-tax-information/maine.md
+++ b/pages/smarttax/state-tax-information/maine.md
@@ -12,6 +12,6 @@ contact:
   phone: 207-624-9693
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Maine Revenue Services Sales, Fuel & Special Tax Division Instructional Bulletin 36](https://www.maine.gov/revenue/sites/maine.gov.revenue/files/inline-files/Bull3620160404.pdf)

--- a/pages/smarttax/state-tax-information/maryland.md
+++ b/pages/smarttax/state-tax-information/maryland.md
@@ -12,7 +12,7 @@ contact:
   phone: 800-638-2937
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Business tax tip #6 Retail Sales Involving Exemption Certificates](https://www.marylandtaxes.gov/forms/Business_Tax_Tips/bustip6.pdf)
 * [Tax Exemptions](https://www.marylandtaxes.gov/business/sales-use/tax-exemptions/) - Section for Tax Exempt Sales to Government Employees

--- a/pages/smarttax/state-tax-information/massachusetts.md
+++ b/pages/smarttax/state-tax-information/massachusetts.md
@@ -12,9 +12,9 @@ contact:
   phone: 617-887-6367
 ---
 
-## Required forms
+## Forms
 
-### CBA Travel card
+### CBA Travel Card
 
 #### Notes
 
@@ -23,7 +23,7 @@ To claim exemption as a federal employee you must provide the hotel with the fol
 * A government identification.
 * Proof on agency letterhead or electronically by authorized personnel indicating that the employee is traveling at the direction of the federal government during the period of occupancy, including the reason, dates, and location for travel.
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Directive 18-1: Taxation of Purchases and Room Rentals by Government Employees](https://www.mass.gov/directive/directive-18-1-taxation-of-purchases-and-room-rentals-by-government-employees)
 * [TIR 01-21: Room Occupancy Excise Exemption for Employees of the United States](https://www.mass.gov/technical-information-release/tir-01-21-room-occupancy-excise-exemption-for-employees-of-the-united-states)

--- a/pages/smarttax/state-tax-information/michigan.md
+++ b/pages/smarttax/state-tax-information/michigan.md
@@ -12,8 +12,8 @@ contact:
   phone: 517-636-4357
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Form 3372 Michigan Sales and Use Tax Certificate of Exemption](https://www.michigan.gov/taxes/business-taxes/sales-use-tax/2023-sales-and-use-tax-forms)

--- a/pages/smarttax/state-tax-information/minnesota.md
+++ b/pages/smarttax/state-tax-information/minnesota.md
@@ -12,12 +12,12 @@ contact:
   phone: 800-657-3777 or 651-296-6181
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Form ST3, Certificate of Exemption](https://www.revenue.state.mn.us/form-search?search_text=&field_document_type=All&field_audience=All&field_tax_type=176&field_tax_year=All)
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Sales Tax Fact Sheet 142](https://www.revenue.state.mn.us/sites/default/files/2021-03/FS142.pdf)

--- a/pages/smarttax/state-tax-information/mississippi.md
+++ b/pages/smarttax/state-tax-information/mississippi.md
@@ -12,7 +12,7 @@ contact:
   phone: 601-923-7700
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Sales Tax Exemptions](https://www.dor.ms.gov/business/sales-tax-exemptions)
 * [Sales Tax Frequently Asked Questions](https://www.dor.ms.gov/business/sales-tax-frequently-asked-questions#:~:text=Does%20Mississippi%20impose%20a%20sales,are%20exemptions%20provided%20by%20law.) - Question for “Are sales to federal, state, county, and city governments exempt from sales tax?”

--- a/pages/smarttax/state-tax-information/missouri.md
+++ b/pages/smarttax/state-tax-information/missouri.md
@@ -12,6 +12,6 @@ contact:
   phone: 573-751-2836
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Sales Tax Taxability and Exemptions](https://dor.mo.gov/faq/taxation/business/sales-use-tax-exemptions.html#:~:text=No.,to%20obtain%20an%20exemption%20letter.) - Question “Are federal employees required to have an exemption letter in the name of the agency they are representing?”

--- a/pages/smarttax/state-tax-information/montana.md
+++ b/pages/smarttax/state-tax-information/montana.md
@@ -4,7 +4,7 @@ layout: layouts/state-tax
 name: Montana
 exceptionsApply: true
 summary:
-  - The state does not have a sales tax, instead it assesses a lodging sales tax for hotel stay.
+  - The state does not have a sales tax; instead it assesses a lodging sales tax for hotel stay.
   - Centrally billed accounts (CBA) are exempt from the lodging sales tax.
 contact:
   name: Montana Department of Revenue
@@ -12,7 +12,7 @@ contact:
   phone: 866-859-2254 or 406-444-5828
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [42.14.303 Exempt Accommodations and Accommodation Sales](https://rules.mt.gov/gateway/ruleno.asp?RN=42.14.303)
 * [Accommodations Taxes](https://leg.mt.gov/content/Publications/fiscal/leg_reference/Brochures/Accommodations-Taxes-2020_Final.pdf)

--- a/pages/smarttax/state-tax-information/nebraska.md
+++ b/pages/smarttax/state-tax-information/nebraska.md
@@ -12,13 +12,13 @@ contact:
   phone: 402-471-5729 or 800-742-7474
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Form 13 Nebraska Resale or Exempt Sale Certificate for Sales Tax Exemption](https://revenue.nebraska.gov/about/forms/sales-and-use-tax-forms)
 * [Streamlined Sales Tax Certificate of Exemption](https://revenue.nebraska.gov/sites/revenue.nebraska.gov/files/doc/streamline/Exemption_Certificate_12-21-2021.pdf)
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Nebraska Sales Tax Guide for Charge Card Purchases by United States (Federal) Government Employees](https://revenue.nebraska.gov/files/doc/info/6-494.pdf)

--- a/pages/smarttax/state-tax-information/new-hampshire.md
+++ b/pages/smarttax/state-tax-information/new-hampshire.md
@@ -12,6 +12,6 @@ contact:
   phone: 603-230-5000
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Frequently Asked Questions](https://www.revenue.nh.gov/faq/meals-rooms.htm) - Meals and Rooms (Rentals) Tax - Refer to the question, “Are non-profit organizations exempt from the Meals and Rooms (Rentals) Tax?”

--- a/pages/smarttax/state-tax-information/new-jersey.md
+++ b/pages/smarttax/state-tax-information/new-jersey.md
@@ -12,9 +12,9 @@ contact:
   phone: 609-826-4400 or 800-323-4400
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Form ST-4 Exempt Use Certificate](https://www.state.nj.us/treasury/taxation/pdf/other_forms/sales/st4.pdf) <span class="usa-tag">Optional</span>
 
@@ -25,6 +25,6 @@ No forms are required. However, cardholders must provide vendors with one of the
 * Signed document on agency letterhead authorizing the official government purchase.
 * For cash purchases under $150, the submission of [Form ST-4](https://www.nj.gov/treasury/taxation/prntsale.shtml), above.
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Tax Topic Bulletin S&U-6](https://www.state.nj.us/treasury/taxation/pdf/pubs/sales/su6.pdf) - See page 18, “Exempt Use Certificate”

--- a/pages/smarttax/state-tax-information/new-mexico.md
+++ b/pages/smarttax/state-tax-information/new-mexico.md
@@ -4,7 +4,7 @@ layout: layouts/state-tax
 name: New Mexico
 exceptionsApply: true
 summary:
-  - The state does not have a sales tax, instead it assesses a gross receipts tax on merchants.
+  - The state does not have a sales tax; instead it assesses a gross receipts tax on merchants.
   - Individually billed accounts (IBA) are not exempt from the gross receipts tax.
   - Centrally billed accounts (CBA) may be exempt from the gross receipts tax.
 contact:
@@ -13,15 +13,15 @@ contact:
   phone: 866-285-2996
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 #### Notes
 
 No forms are required, however the federal government is only exempt from specific types of transactions in New Mexico. CBAs are not subject to gross receipts taxes on tangible property but are eligible for intangible property (e.g., lodging).  Cardholders should be able to present the CBA card, which must indicate “United States of America," however merchants can request a Type 9 nontaxable transaction certificate.
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Gross Receipts Tax](https://www.tax.newmexico.gov/all-nm-taxes/2020/12/20/what-is-new-mexicos-sales-tax-rate/)
 * [New Mexico FYI-240 Transactions with Government Agencies](https://www.tax.newmexico.gov/governments/governmental-gross-receipts-tax/)

--- a/pages/smarttax/state-tax-information/new-york.md
+++ b/pages/smarttax/state-tax-information/new-york.md
@@ -12,9 +12,9 @@ contact:
   phone: 518-485-2889
 ---
 
-## Required forms
+## Forms
 
-### Travel card
+### Travel Card
 
 * [Form ST-129 New York State and Local Sales and Use Tax Exemption Certificate - Tax on occupancy of hotel or motel rooms](https://www.tax.ny.gov/forms/sales_tax_exemption_documents.htm)
 
@@ -22,7 +22,7 @@ contact:
 
 Form ST-129 cannot be used to claim exemption from locally imposed hotel occupancy taxes (e.g., local bed tax). When presenting the certificate, provide government identification.
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Publication 848:(2/15):A Guide to Sales Tax for Hotel and Motel Operators](https://www.tax.ny.gov/pdf/publications/sales/pub848.pdf) - Section “The United States of America and any of its agencies or instrumentalities”
 * [Tax Bulletin ST-700 (TB-ST-700) Purchases and Sales by Governmental Entities](https://www.tax.ny.gov/pubs_and_bulls/tg_bulletins/st/purchases_and_sales_by_governmental_entities.htm)

--- a/pages/smarttax/state-tax-information/north-carolina.md
+++ b/pages/smarttax/state-tax-information/north-carolina.md
@@ -18,11 +18,7 @@ contact:
 
 * [Form E-595E 4-2022, Streamlined Sales and Use Tax Agreement Certificate of Exemption](https://www.ncdor.gov/taxes-forms/sales-and-use-tax/sales-and-use-tax-forms-and-certificates/exemption-certificates/form-e-595e-streamlined-sales-and-use-tax-certificate-exemption)
 
-#### Notes
-
 ## Laws, Regulations, Policies
 
 * [Sales and Use Tax, Sale and Purchase Exemptions, United States Government](https://www.ncdor.gov/taxes-forms/sales-and-use-tax/sale-and-purchase-exemptions/united-states-government#:~:text=Sales%20by%20and%20sales%20directly,to%20sales%20or%20use%20tax.)
 * [Sales and Use Tax Bulletins](https://www.ncdor.gov/media/13881/open) - 36-1 Sales by and Sales to the United States Government, or any Qualifying Agencies or Instrumentalities Thereof
-
-#### Notes

--- a/pages/smarttax/state-tax-information/north-carolina.md
+++ b/pages/smarttax/state-tax-information/north-carolina.md
@@ -12,15 +12,15 @@ contact:
   phone: 877-252-3052
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Form E-595E 4-2022, Streamlined Sales and Use Tax Agreement Certificate of Exemption](https://www.ncdor.gov/taxes-forms/sales-and-use-tax/sales-and-use-tax-forms-and-certificates/exemption-certificates/form-e-595e-streamlined-sales-and-use-tax-certificate-exemption)
 
 #### Notes
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Sales and Use Tax, Sale and Purchase Exemptions, United States Government](https://www.ncdor.gov/taxes-forms/sales-and-use-tax/sale-and-purchase-exemptions/united-states-government#:~:text=Sales%20by%20and%20sales%20directly,to%20sales%20or%20use%20tax.)
 * [Sales and Use Tax Bulletins](https://www.ncdor.gov/media/13881/open) - 36-1 Sales by and Sales to the United States Government, or any Qualifying Agencies or Instrumentalities Thereof

--- a/pages/smarttax/state-tax-information/north-dakota.md
+++ b/pages/smarttax/state-tax-information/north-dakota.md
@@ -12,16 +12,16 @@ contact:
   phone: 701-328-1246
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [SFN 21919 (6-2021) Application for Sales Tax Exemption Certificate](https://www.tax.nd.gov/sites/www/files/documents/forms/application-for-sales-tax-exemption-certificate.pdf)
 
-### CBA Travel card
+### CBA Travel Card
 
 * [SFN 21937 (11-2011) Exemption Certificate For Government And Qualifying School Lodging Accommodations](https://www.tax.nd.gov/sites/www/files/documents/forms/exemption-certificate-for-govt-and-qualifying-school-lodging-accommodations.pdf)
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Guideline - Sales Tax: Exempt Organizations](https://www.tax.nd.gov/sites/www/files/documents/guidelines/business/sales-use/guideline-exempt-organizations.pdf)

--- a/pages/smarttax/state-tax-information/ohio.md
+++ b/pages/smarttax/state-tax-information/ohio.md
@@ -12,9 +12,9 @@ contact:
   phone: 888-405-4039
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Sales and Use Tax Blanket Exemption Certificate](https://tax.ohio.gov/static/forms/fill-in/sales_and_use/exemption_certificates/st_stec_b_fi.pdf) <span class="usa-tag">Optional</span>
 

--- a/pages/smarttax/state-tax-information/oklahoma.md
+++ b/pages/smarttax/state-tax-information/oklahoma.md
@@ -12,7 +12,7 @@ contact:
   phone: 405-521-3160
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Oklahoma Sales Tax Exemption Packet](https://oklahoma.gov/content/dam/ok/en/tax/documents/forms/businesses/general/Packet-E.pdf) - See p. 19, Item 61
 * [Chapter 65 Sales and Use Tax](https://oklahoma.gov/content/dam/ok/en/tax/documents/resources/rules-and-policies/agency-rules/proposed-rules/710-Chapter-65.pdf) - See p. 12, 710:65-7-15. Vendors' responsibility - sales to entities with other specific statutory exemptions

--- a/pages/smarttax/state-tax-information/oregon.md
+++ b/pages/smarttax/state-tax-information/oregon.md
@@ -4,7 +4,7 @@ layout: layouts/state-tax
 name: Oregon
 exceptionsApply: true
 summary:
-  - The state does not have a sales tax, instead it assesses a transient lodging tax for hotel stay.
+  - The state does not have a sales tax; instead it assesses a transient lodging tax for hotel stay.
   - Individually billed accounts (IBA) are exempt from transient lodging tax.
 contact:
   name: Oregon Department of Revenue
@@ -12,14 +12,14 @@ contact:
   phone: 503-378-4988 or 800-356-4222
 ---
 
-## Required forms
+## Forms
 
-### Travel card
+### Travel Card
 
 #### Notes
 
 Proof of federal employment may be required.
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Transient Lodging Tax - Exemptions](https://www.oregon.gov/DOR/programs/businesses/Pages/lodging.aspx)

--- a/pages/smarttax/state-tax-information/pennsylvania.md
+++ b/pages/smarttax/state-tax-information/pennsylvania.md
@@ -12,12 +12,12 @@ contact:
   phone: 717-787-1064
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Form REV-1220 (TR) 03-22 Exemption Certificate](https://revenue-pa.custhelp.com/app/answers/detail/a_id/424/~/when-should-i-use-a-rev-1220-pa-exemption-certificate%3F)
 
-### Travel card
+### Travel Card
 
 * [Form REV-1220 (TR) 03-22 Exemption Certificate](https://revenue-pa.custhelp.com/app/answers/detail/a_id/424/~/when-should-i-use-a-rev-1220-pa-exemption-certificate%3F)

--- a/pages/smarttax/state-tax-information/puerto-rico.md
+++ b/pages/smarttax/state-tax-information/puerto-rico.md
@@ -12,14 +12,14 @@ contact:
   phone: 787-721-2020
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Puerto Rico Department of Treasury Form AS2916.1 (English Version)](http://www.hacienda.pr.gov/sites/default/files/documentos/as_2916_1_2015.pdf)
 * [Puerto Rico Department of Treasury Form SC2916 (Spanish Version)](http://www.hacienda.gobierno.pr/sites/default/files/documentos/sc_2916_2015_1.pdf)
 
-### Travel card
+### Travel Card
 
 * [Request for Room Tax Exemption](https://roomtax.prtourism.com/exemption_reqs.php?lan)
 

--- a/pages/smarttax/state-tax-information/south-carolina.md
+++ b/pages/smarttax/state-tax-information/south-carolina.md
@@ -12,7 +12,7 @@ contact:
   phone: 844-898-8542
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [SC REVENUE RULING #09-1](https://dor.sc.gov/resources-site/lawandpolicy/Advisory%20Opinions/RR09-1.pdf)
 * [SC REVENUE RULING #13-2](https://dor.sc.gov/resources-site/lawandpolicy/Advisory%20Opinions/RR13-2.pdf)

--- a/pages/smarttax/state-tax-information/south-dakota.md
+++ b/pages/smarttax/state-tax-information/south-dakota.md
@@ -12,12 +12,12 @@ contact:
   phone: 800-829-9188
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Form:2040 Streamlined Sales and Use Tax Certificate of Exemption](https://sddor.seamlessdocs.com/f/2040)
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Exempt Entities](https://dor.sd.gov/media/sgxnhnhl/exemptentities.pdf#:~:text=Federal%20Government%20and%20the%20South%20Dakota%20Department%20of,required%20to%20collect%20sales%20tax%20on%20taxable%20sales.)

--- a/pages/smarttax/state-tax-information/tennessee.md
+++ b/pages/smarttax/state-tax-information/tennessee.md
@@ -12,12 +12,12 @@ contact:
   phone: 615-253-0600
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Tennessee Sales or Use Tax Government Certificate of Exemption](https://www.tn.gov/revenue/taxes/sales-and-use-tax/forms.html)
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [09-01 - Purchases by Government Employees](https://www.tn.gov/content/dam/tn/revenue/documents/notices/sales/sales09-01.pdf)

--- a/pages/smarttax/state-tax-information/texas.md
+++ b/pages/smarttax/state-tax-information/texas.md
@@ -12,18 +12,18 @@ contact:
   phone: 800-252-5555
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Form 01-339, Texas Sales and Use Tax Resale Certificate / Exemption Certification](https://comptroller.texas.gov/taxes/exempt/forms//)
 
-### Travel card
+### Travel Card
 
 * [Form 12-302, Texas Hotel Occupancy Tax Exemption Certification](https://comptroller.texas.gov/taxes/hotel/forms/)
 * [Form 14-305, Motor Vehicle Verification Certificate for Rental Tax](https://comptroller.texas.gov/taxes/motor-vehicle/forms/)
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Guidelines to Texas Tax Exemptions](https://comptroller.texas.gov/taxes/publications/96-1045.php) - Select AP-204 Federal and all Others
 * [Texas Administrative Code, Rule 3.322 Exempt Organizations](https://texreg.sos.state.tx.us/public/readtac$ext.TacPage?sl=T&app=9&p_dir=F&p_rloc=207487&p_tloc=14750&p_ploc=1&pg=2&p_tac=&ti=34&pt=1&ch=3&rl=322) - Sections (C) and (G)

--- a/pages/smarttax/state-tax-information/utah.md
+++ b/pages/smarttax/state-tax-information/utah.md
@@ -12,8 +12,8 @@ contact:
   phone: 801-297-2200 or 800-662-4335
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [TC-721G Utah State Tax Commission Exemption Certificate for Government](https://tax.utah.gov/forms-pubs)

--- a/pages/smarttax/state-tax-information/vermont.md
+++ b/pages/smarttax/state-tax-information/vermont.md
@@ -12,8 +12,8 @@ contact:
   phone: 802-828-2551
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [F0003 Streamlined Exemption Certificate](https://tax.vermont.gov/business/nonprofits/exemption-certificates)

--- a/pages/smarttax/state-tax-information/virgin-islands.md
+++ b/pages/smarttax/state-tax-information/virgin-islands.md
@@ -12,10 +12,10 @@ contact:
   phone: 340-715-1040
 ---
 
-## Required forms
+## Forms
 
-### Travel card
+### Travel Card
 
 #### Notes
 
-For IBA Travel cards, official government identification is required.
+For IBA Travel Cards, official government identification is required.

--- a/pages/smarttax/state-tax-information/virginia.md
+++ b/pages/smarttax/state-tax-information/virginia.md
@@ -12,7 +12,7 @@ contact:
   phone: 804-367-8037
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Sales Tax Exemptions](https://www.tax.virginia.gov/sales-tax-exemptions)
 * [Rulings of the Tax Commissioner: Retail Sales and Use Tax](https://www.tax.virginia.gov/laws-rules-decisions/rulings-tax-commissioner/02-105)

--- a/pages/smarttax/state-tax-information/washington.md
+++ b/pages/smarttax/state-tax-information/washington.md
@@ -12,6 +12,6 @@ contact:
   phone: 360-705-6705
 ---
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [US government sales](https://dor.wa.gov/education/industry-guides/lodging-guide/us-government-sales#:~:text=Sales%20made%20directly%20to%20the,reimbursement%20from%20the%20federal%20government.)

--- a/pages/smarttax/state-tax-information/west-virginia.md
+++ b/pages/smarttax/state-tax-information/west-virginia.md
@@ -12,12 +12,12 @@ contact:
   phone: 800-982-8297
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [F0003 Streamlined Sales and Use Tax Certificate of Exemption](https://tax.wv.gov/Business/SalesAndUseTax/StreamlinedSalesAndUseTax/Pages/StreamlinedSalesAndUseTax.aspx)
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Sales and Use Tax Exemptions](https://tax.wv.gov/Documents/TSD/tsd300.pdf)

--- a/pages/smarttax/state-tax-information/wisconsin.md
+++ b/pages/smarttax/state-tax-information/wisconsin.md
@@ -12,14 +12,14 @@ contact:
   phone: 608-266-2776
 ---
 
-## Required forms
+## Forms
 
-### Travel & Purchase card
+### Travel & Purchase Card
 
 * [Form S-211 Wisconsin Sales and Tax Exemption Certificate](https://www.revenue.wi.gov/Pages/FAQS/pcs-s-exempt.aspx)
 * [Form S-211E Electronic Wisconsin Sales and Use Tax Exemption Certificate](https://www.revenue.wi.gov/Pages/SalesAndUse/ExemptionCertificate.aspx)
 * [May 2022 S-211-SST Wisconsin Streamlined Sales and Use Tax Agreement Exemption Certificate](https://www.revenue.wi.gov/Pages/FAQS/pcs-s-exempt.aspx)
 
-## State laws, regulations, policies
+## Laws, Regulations, Policies
 
 * [Exempt Sales to the Federal Government](https://www.revenue.wi.gov/Pages/TaxPro/2010/news-2010-100816.aspx#:~:text=Sales%20to%20the%20United%20States,Wisconsin%20sales%20and%20use%20taxes.)

--- a/pages/smarttax/state-tax-information/wyoming.md
+++ b/pages/smarttax/state-tax-information/wyoming.md
@@ -12,9 +12,9 @@ contact:
   phone: 307-777-5275
 ---
 
-## Required forms
+## Forms
 
-### Purchase card
+### Purchase Card
 
 * [Streamlined Sales and Use Tax Agreement Certificate of Exemption](https://sao.wyo.gov/wp-content/uploads/2019/10/exempt.pdf)
 


### PR DESCRIPTION
- We started the build on state tax pages before the style guide was complete.
  - The style guide prescribes the use of title case for headings
  - Tax pages currently use sentence case for headings

- Converts sentence case headings to title case headings
- Cleans up headings (reduces redundant instances of "state")
- Replaces commas with semicolons when separating independent clauses