### PR TITLE
Replaces auto-generated footnotes with manual footnotes

### DIFF
--- a/src/content/about/refunds.md
+++ b/src/content/about/refunds.md
@@ -23,17 +23,18 @@ Example refund calculations can be found in section B.3.3 of the [GSA SmartPay 3
 
 ## Refund Background
 
-Unless an agency has specific statutory authority to handle funds received, 31 U.S.C. § 3302 states that incoming funds are to be deposited into the Treasury general fund. The exception to this rule is when funds qualify as "refunds" which are defined as "repayments for excess payments." Or, refunds can be defined as "amounts collected from outside sources for payments made in error, overpayments or adjustments for previous amounts disbursed." Under either definition, these "refunds" must go back to the appropriation or fund account(s) from which the excess payment were made.[^1] [^2]
-
-[^1]: Sources: Rebates from Travel Management Center Contractors, B-217913, 65 Comp. Gen. 600; May 30, 1986.
-[^2]: Accounting for Rebates from Travel Management Center Contractors, B-217913.3, 73 Comp. Gen. 210, June 24, 1994.  
+Unless an agency has specific statutory authority to handle funds received, 31 U.S.C. § 3302 states that incoming funds are to be deposited into the Treasury general fund. The exception to this rule is when funds qualify as "refunds" which are defined as "repayments for excess payments." Or, refunds can be defined as "amounts collected from outside sources for payments made in error, overpayments or adjustments for previous amounts disbursed." Under either definition, these "refunds" must go back to the appropriation or fund account(s) from which the excess payment were made.<sup>1</sup> <sup>2</sup>
 
 GSA originally looked into the use of refunds as part of the travel management company contracts. The Comptroller General found that if the contractor agreed to discount services to the federal government, the Government Accountability Office saw no reason prohibiting agencies from depositing savings to the credit of the appropriation against which the initial cost of the employee travel was charged.
 
-As receipts are actually a return of a portion of a prior agency payment and may be deposited to the credit of the appropriation against which the payment was initially charged rather than to a general fund receipt account. If the appropriation initially charged has not expired, the refund is available to support new obligations. If the appropriation account initially charged has expired, but has not yet closed, the refund is deposited to the credit of the expired account where it is available for recording or adjusting obligations properly incurred before the appropriation expired. [^3]
-
-[^3]: Sources:  71 Comp. Gen. 502 (1992); B-217913.2, Feb. 19, 1993; GAO, Policy and Procedures Manual for Guidance of Federal Agencies, title 7, §§ 4.3, 5.4 ; 31 U.S.C. § 1552(b).
+As receipts are actually a return of a portion of a prior agency payment and may be deposited to the credit of the appropriation against which the payment was initially charged rather than to a general fund receipt account. If the appropriation initially charged has not expired, the refund is available to support new obligations. If the appropriation account initially charged has expired, but has not yet closed, the refund is deposited to the credit of the expired account where it is available for recording or adjusting obligations properly incurred before the appropriation expired.<sup>3</sup>
 
 This same analysis and reasoning applies to the GSA SmartPay Program refunds. Under the GSA SmartPay program, refunds are discounts offered by the banks, which may be deposited to the credit of the appropriation against which the initial cost was charged. If that appropriation has expired, but not yet closed, the refund may be credited to the expired account where available. If the appropriation has expired, and the expired account has been closed, the refund would be properly credited to the appropriate Treasury general fund.
 
 The exception permitting the deposit of refunds to the appropriation initially charged is permissive in nature. If an agency declines the refund, it should be deposited to the Treasury general fund.
+
+### Sources
+
+1. [Rebates from Travel Management Center Contractors](https://www.gao.gov/products/b-217913), B-217913, 65 Comp. Gen. 600; May 30, 1986.
+1. [Accounting for Rebates from Travel Management Center Contractors](https://www.gao.gov/products/b-217913.3), B-217913.3, 73 Comp. Gen. 210, June 24, 1994.
+1. [71 Comp. Gen. 502 (1992)](https://www.gao.gov/products/b-245856.7); [B-217913.2](https://www.gao.gov/products/b-217913.2), Feb. 19, 1993; [GAO, Policy and Procedures Manual for Guidance of Federal Agencies](https://www.gao.gov/products/149099), title 7, §§ 4.3, 5.4 ; 31 U.S.C. § 1552(b).


### PR DESCRIPTION
There is (just) one page that contains source references (Refunds). We initially used markdown footnotes for this, the benefit of which is automated functionality to link the footnotes in the body text to the respective source, create an auto-generated, ordered list of all footnotes, and separate the section with a subheading.

Unfortunately, the subheading is auto-generated as an `h2`, with no obvious way to control the heading level. This is problematic for two reasons: 

1. The footnotes are semantically children of an existing `h2` ("Refunds Background")
2. All `h2`s are included in the side navigation, and "Footnotes" doesn't merit such a nav item

This PR makes two changes:
- Converts footnotes from the markdown syntax that controls behavior and styling to manual footnotes with HTML `sup` elements, with sources manually curated under an `h3` heading ("Sources")
- Adds links to the GAO sources listed

## 🔍 Preview

- [Branch preview link](https://federalist-ab31a10d-375d-4040-9324-1ae94e8a36b9.sites.pages.cloud.gov/preview/gsa/smartpay-website/rj-footnotes/about/refunds/)