### PR TITLE
Adds stakeholders section pages

### DIFF
--- a/src/content/stakeholders/account-holders.md
+++ b/src/content/stakeholders/account-holders.md
@@ -1,0 +1,29 @@
+---
+title: Card/Account Holder Responsibilities
+description: "Account holders must comply with agency regulations and rules, maintain records, and keep their account secure."
+intro: "The account holder, also known as the cardholder, is the individual or agency/organization component designated by an agency/organization to receive a GSA SmartPay® account."
+order: 1
+category: stakeholders
+tags:
+  - account
+  - cardholder
+  - banks
+---
+
+The account holder is responsible for:
+
+- Securing the account.
+- Maintaining records relating to all transactions.
+- Using the account ethically and appropriately.
+- Observing all dollar limits.
+- Reconciling and documenting transactions.
+
+Account holders must comply with all applicable regulations and procedures of your agency. If you’re unsure about a purchase or you’re unclear about your agency’s policy, please reach out to your agency/organization’s program coordinator (A/OPC) for guidance.
+
+Account holders are also responsible for reporting a lost or stolen GSA SmartPay account. If this occurs, please promptly contact the following parties:
+
+- The contractor bank.
+- Your A/OPC.
+- Your supervisor.
+
+Once an account has been reported as lost or stolen, the contractor bank immediately blocks that account from further usage and a new account number will be issued to the account holder.

--- a/src/content/stakeholders/index.md
+++ b/src/content/stakeholders/index.md
@@ -1,0 +1,80 @@
+---
+title: Key Players in the Process
+description: "The important participants in the GSA SmartPay program and descriptions of their roles"
+intro: "Key program participants in the GSA SmartPay® program include:"
+slug: "./"
+order: 0
+category: stakeholders
+tags:
+  - stakeholders
+  - banks
+  - aopc
+  - contracting officer
+  - account
+---
+
+## Agency/Organization Program Coordinators (A/OPCs)
+
+- Overall management and oversight of the accounts under their span of control.
+- Set up accounts and designate authorization controls.
+- Serve as a liaison between account holders and the bank.
+- Provide ongoing advice and assistance to account holders.
+- Audit accounts as required by the agency’s policy.
+- Use the bank's Electronic Access System (EAS) to perform account management and oversight.
+
+## Approving Officials (AO)
+
+- Typically the account holder’s supervisor.
+- Assure proper use of the account.
+- Determine if purchases are necessary for accomplishing the mission of the agency.
+
+## Account Holders
+
+- Designated by an agency/organization to receive an account.
+- Secure the payment solution.
+- Maintain records relating to transactions, as required.
+- Use the account ethically for official government purposes only.
+
+## Designated Billing Offices (DBO)
+
+- Serve as the focal point for receipt of official centrally billed invoices.
+- Oversee the proper processing of invoices.
+- Ensure invoices are paid within the Prompt Payment Act timeframes.
+
+## Transaction Dispute Officers (TDO)
+
+- Assist the agency/organization and the bank in tracking and resolving disputed transactions.
+
+## EC/EDI Offices (EO)
+
+- Focal point for electronic commerce/electronic data interchange (EC/EDI) for the agency/organization.
+- Oversee the proper implementation of the EC/EDI capabilities and processes.
+
+## Contractor/Issuing Banks
+
+- Enable merchant payments for purchase transactions.
+- Establish accounts.
+- Issue cards, if required.
+- Prepare the monthly statement for each account holder.
+- Issue invoices to the DBO.
+- Provide 24-hour customer service.
+- Prepare reports that assist the agency in effectively utilizing the program.
+- Examples include Citibank and U.S. Bank.
+
+## Brands
+
+- Financial institutions that dictate where payments can be processed.
+- Facilitate the payment process between account holders, merchants and issuing financial institutions.
+- Examples include Visa and Mastercard.
+
+## Merchants
+
+- Source for supplies or services.
+- May be a required source inside or outside the government, another government agency or a private sector merchant.
+
+## GSA Contracting Officer
+
+- Administers the GSA SmartPay Master Contract on behalf of all authorized users, including your agency/organization.
+- Make changes to the GSA SmartPay Master Contract requirements.
+- Legally commit or obligate the government to the expenditure of public funds for the GSA SmartPay Master Contract.
+- Render a final decision on a dispute pertaining to the GSA SmartPay Master Contract.

--- a/src/content/stakeholders/program-coordinators.md
+++ b/src/content/stakeholders/program-coordinators.md
@@ -1,0 +1,30 @@
+---
+title: Program Coordinator Responsibilities
+description: "Program coordinators have a variety of responsibilities as the liaison between agencies, contracting banks, and the account holder."
+intro: "As an agency/organization’s program coordinator (A/OPC), you serve as the liaison between your agency, the contractor bank, the account holder and the GSA Contracting Office. Your role is essential to efficiently and effectively managing your agency’s GSA SmartPay® program."
+order: 2
+category: stakeholders
+tags:
+  - program coordinator
+  - aopc
+  - account
+  - banks
+---
+
+Here are some potential A/OPC responsibilities, which may vary by agency:
+
+- Maintain an up-to-date list of account names, account numbers, addresses, emails, telephone numbers, etc. of all current account holders and accounts.
+- Provide the contractor bank with any changes in your agency's organizational structure that may affect invoice/report distribution.
+- Review and evaluate the contractor's technical and administrative task order performance and compliance.
+- Resolve problems between the contractor bank and account holders.
+- Take appropriate action regarding delinquent accounts and report violations to internal investigative units and the GSA Contracting Officer.
+- Participate in the annual GSA SmartPay Training Forum and train account holders.
+- Ensure account holders use their account correctly.
+- Monitor account activity and manage delinquencies.
+- Ensure that appropriate steps are taken to mitigate suspension or cancellation actions.
+- Develop agency program procedures and policies as necessary.
+- Keep the lines of communication open with all key program participants.
+
+Communication is key. A/OPCs should ensure that all program participants, including senior management/leadership, are aware of what is going on in the program. Keep in touch with your program’s participants by networking, asking questions and sharing or distributing policy changes and program information.
+
+As an A/OPC, you should try to establish relationships with the account holders and Approving Officials (AOs) within your span of control. The better you understand why and how the GSA SmartPay account will be used, the more effective you can be in managing the program.


### PR DESCRIPTION
- Adds three pages in `stakeholders` section

> **Warning**
> Previews won't work, since we don't yet have a `[...slug].astro` page for this section (or for the `how-it-works` section)

> **Note**
> One of page titles in Figma ("Agency/Organization Program Coordinators (A/OPCs) Responsibilities" differs from that of the corresponding google doc ("Program Coordinator Responsibilities"). Also in Figma, the side nav title ("A/OPC Responsibilities") is different than the page title. To my knowledge, the engineers pull the page title for use in the side nav, and I don't think we currently have a way to use a side nav title that's different from the corresponding page title.

> **Note**
> So far, we've assumed a landing page for each section (`index.md`). This page uses "Key Players" for the landing page, which would render at the path `/stakeholders/` instead of `/stakeholders/key-players/`