### PR TITLE
Reverts logos and designs to html table (from markdown-in-html)

### DIFF
--- a/src/content/about/logos.mdx
+++ b/src/content/about/logos.mdx
@@ -22,56 +22,44 @@ tags:
     <tr>
       <th scope="row">GSA SmartPay Logo</th>
       <td>
-        ![GSA SmartPay Logo with GSA star logo, SmartPay, and Supporting your mission](/images/gsa-smartpay-logo_thumb.svg)
+        <img src="/images/gsa-smartpay-logo_thumb.svg" alt="GSA SmartPay Logo with GSA star logo, SmartPay, and Supporting your mission" />
       </td>
-      <td>
-        [Download ZIP file](/files/gsa-smartpay-program-logo.zip)
-      </td>
+      <td><a href="/files/gsa-smartpay-program-logo.zip">Download ZIP file</a></td>
     </tr>
     <tr>
       <th scope="row">Travel Card Design</th>
       <td>
-        ![Blue charge card with the word Travel and numbers 1234 5678 9012 3456 and the name John Smith, with an airplane in the background](/images/blue-card_thumb.png)
+        <img src="/images/blue-card_thumb.png" alt="Blue charge card with the word Travel and numbers 1234 5678 9012 3456 and the name John Smith, with an airplane in the background" />
       </td>
-      <td>
-        [Download ZIP file](/files/gsa-smartpay-travel-card-design.zip)
-      </td>
+      <td><a href="/files/gsa-smartpay-travel-card-design.zip">Download ZIP file</a></td>
     </tr>
     <tr>
       <th scope="row">Purchase Card Design</th>
       <td>
-        ![Red charge card with the word Purchase and numbers 1234 5678 9012 3456 and the name John Smith, with a bird in the background](/images/red-card_thumb.png)
+        <img src="/images/red-card_thumb.png" alt="Red charge card with the word Purchase and numbers 1234 5678 9012 3456 and the name John Smith, with a bird in the background"/>
       </td>
-      <td>
-        [Download ZIP file](/files/gsa-smartpay-purchase-card-design.zip)
-      </td>
+      <td><a href="/files/gsa-smartpay-purchase-card-design.zip">Download ZIP file</a></td>
     </tr>
     <tr>
       <th scope="row">Fleet Card Design</th>
       <td>
-        ![Green charge card with the word Fleet and numbers 1234 5678 9012 3456 and the name John Smith, with a road in the background](/images/green-card_thumb.png)
+        <img src="/images/green-card_thumb.png" alt="Green charge card with the word Fleet and numbers 1234 5678 9012 3456 and the name John Smith, with a road in the background" />
       </td>
-      <td>
-        [Download ZIP file](/files/gsa-smartpay-fleet-card-design.zip)
-      </td>
+      <td><a href="/files/gsa-smartpay-fleet-card-design.zip">Download ZIP file</a></td>
     </tr>
     <tr>
       <th scope="row">Integrated Card Design</th>
       <td>
-        ![Yellow charge card with the word Intergrated and numbers 1234 5678 9012 3456 and the name John Smith, with a globe outline in the background](/images/yellow-card_thumb.png)
+        <img src="/images/yellow-card_thumb.png" alt="Yellow charge card with the word Intergrated and numbers 1234 5678 9012 3456 and the name John Smith, with a globe outline in the background" />
       </td>
-      <td>
-        [Download ZIP file](/files/gsa-smartpay-integrated-card-design.zip)
-      </td>
+      <td><a href="/files/gsa-smartpay-integrated-card-design.zip">Download ZIP file</a></td>
     </tr>
     <tr>
       <th scope="row">Tax Advantage Card Design</th>
       <td>
-        ![Silver charge card with the words Tax advantage and numbers 1234 5678 9012 3456 and the name John Smith, with a car and buildings in the background](/images/silver-card_thumb.png)
+        <img src="/images/silver-card_thumb.png" alt="Silver charge card with the words Tax advantage and numbers 1234 5678 9012 3456 and the name John Smith, with a car and buildings in the background" />
       </td>
-      <td>
-        [Download ZIP file](/files/gsa-smartpay-tax-advantage-card-design.zip)
-      </td>
+      <td><a href="/files/gsa-smartpay-tax-advantage-card-design.zip">Download ZIP file</a></td>
     </tr>    
   </tbody>
 </table>


### PR DESCRIPTION
- Reverts logos and designs table from using markdown in HTML (to resolve image paths in cloud.gov pages) to using HTML
- Takes advantage of #168 to use `img` tags in HTML table

The markdown-in-HTML approach worked fine, but it added a `p` element around every image in the table cell. This had the effect of adding additional margin to each table cell. Using HTML instead of markdown in HTML clears this unwanted white space, and removes unnecessary `p` elements from the table.

## Before
![Screenshot of logos and designs page with rows for logo and card designs with white space above and below the content of table cells](https://github.com/GSA/smartpay-website/assets/32855580/94ed8b76-b45b-4798-ba16-76bf1aea61be)

## This PR
![Screenshot of logos and designs page with rows for logo and card designs with reduced white space above and below the content of table cells](https://github.com/GSA/smartpay-website/assets/32855580/f4dc6f0f-0693-4bd3-830f-c1881038464e)
