### PR TITLE
add a robots.txt file for search.gov

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import sitemap from "@astrojs/sitemap";
 
 // https://astro.build/config
 export default defineConfig({
-    site: 'https://smartpay.gsa.gov',
+    site: 'https://federalist-ab31a10d-375d-4040-9324-1ae94e8a36b9.sites.pages.cloud.gov/site/gsa/smartpay-website/',
     base: process.env.BASEURL,
     integrations: [mdx(), sitemap()],
     outDir: '_site',

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "federalist": "astro build",
     "serve": "npm run build && npm run preview -- --port 8080",
     "pa11y-ci": "npm run pa11y-ci:desktop && npm run pa11y-ci:mobile",
-    "pa11y-ci:desktop": "pa11y-ci --config ./.pa11yci-desktop --sitemap http://localhost:8080/sitemap-0.xml   --sitemap-find \"^https://smartpay.gsa.gov/\" --sitemap-replace \"http://localhost:8080/\"",
-    "pa11y-ci:mobile": "pa11y-ci --config ./.pa11yci-mobile --sitemap http://localhost:8080/sitemap-0.xml   --sitemap-find \"^https://smartpay.gsa.gov\" --sitemap-replace \"http://localhost:8080/\"",
+    "pa11y-ci:desktop": "pa11y-ci --config ./.pa11yci-desktop --sitemap http://localhost:8080/sitemap-0.xml   --sitemap-find \"^https://federalist-ab31a10d-375d-4040-9324-1ae94e8a36b9.sites.pages.cloud.gov/site/gsa/smartpay-website/\" --sitemap-replace \"http://localhost:8080/\"",
+    "pa11y-ci:mobile": "pa11y-ci --config ./.pa11yci-mobile --sitemap http://localhost:8080/sitemap-0.xml   --sitemap-find \"^https://federalist-ab31a10d-375d-4040-9324-1ae94e8a36b9.sites.pages.cloud.gov/site/gsa/smartpay-website/\" --sitemap-replace \"http://localhost:8080/\"",
     "pa11y-ci:gh": "npx start-server-and-test serve http://localhost:8080 pa11y-ci"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "federalist": "astro build",
     "serve": "npm run build && npm run preview -- --port 8080",
     "pa11y-ci": "npm run pa11y-ci:desktop && npm run pa11y-ci:mobile",
-    "pa11y-ci:desktop": "pa11y-ci --config ./.pa11yci-desktop --sitemap http://localhost:8080/sitemap-0.xml   --sitemap-find \"^https://federalist-ab31a10d-375d-4040-9324-1ae94e8a36b9.sites.pages.cloud.gov/site/gsa/smartpay-website/\" --sitemap-replace \"http://localhost:8080/\"",
-    "pa11y-ci:mobile": "pa11y-ci --config ./.pa11yci-mobile --sitemap http://localhost:8080/sitemap-0.xml   --sitemap-find \"^https://federalist-ab31a10d-375d-4040-9324-1ae94e8a36b9.sites.pages.cloud.gov/site/gsa/smartpay-website/\" --sitemap-replace \"http://localhost:8080/\"",
+    "pa11y-ci:desktop": "pa11y-ci --config ./.pa11yci-desktop --sitemap http://localhost:8080/sitemap-0.xml   --sitemap-find \"^https://federalist-ab31a10d-375d-4040-9324-1ae94e8a36b9.sites.pages.cloud.gov/\" --sitemap-replace \"http://localhost:8080/\"",
+    "pa11y-ci:mobile": "pa11y-ci --config ./.pa11yci-mobile --sitemap http://localhost:8080/sitemap-0.xml   --sitemap-find \"^https://federalist-ab31a10d-375d-4040-9324-1ae94e8a36b9.sites.pages.cloud.gov/\" --sitemap-replace \"http://localhost:8080/\"",
     "pa11y-ci:gh": "npx start-server-and-test serve http://localhost:8080 pa11y-ci"
   },
   "dependencies": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://federalist-ab31a10d-375d-4040-9324-1ae94e8a36b9.sites.pages.cloud.gov/site/gsa/smartpay-website/sitemap-index.xml


### PR DESCRIPTION
This adds a robots.txt to allow discovery of the sitemap. This is mostly for testing with search.gov — we will want to change the domain before going live).