### PR TITLE
Resize card images

### DIFF
--- a/src/content/smarttax/recognizing-your-account.mdx
+++ b/src/content/smarttax/recognizing-your-account.mdx
@@ -34,9 +34,9 @@ _Sixth-digit identifiers for IBAs apply to the travel business line only._
 
 | Card | Sixth digit | Billing type |
 | -----| ----------- | ------------ |
-|![Blue charge card with the word Travel and numbers 1234 5678 9012 3456 and the name John Smith, with an airplane in the background](/images/blue-card_thumb.png) <br />IBA Travel Card | 1, 2, 3, 4 | Individually Billed (IBA) |
-|![Blue charge card with the word Travel and numbers 1234 5678 9012 3456 and the name John Smith, with an airplane in the background](/images/blue-card_thumb.png) <br />CBA Travel Card | 6, 7, 8, 9, 0 | Centrally Billed (CBA) |
-|![Silver charge card with the words Tax advantage and numbers 1234 5678 9012 3456 and the name John Smith, with a car and buildings in the background](/images/silver-card_thumb.png) <br />Tax Advantage Travel Card  | 5 | IBA/CBA | 
+|![Blue charge card with the word Travel and numbers 1234 5678 9012 3456 and the name John Smith, with an airplane in the background](/images/blue-card.svg) <br />IBA Travel Card | 1, 2, 3, 4 | Individually Billed (IBA) |
+|![Blue charge card with the word Travel and numbers 1234 5678 9012 3456 and the name John Smith, with an airplane in the background](/images/blue-card.svg) <br />CBA Travel Card | 6, 7, 8, 9, 0 | Centrally Billed (CBA) |
+|![Silver charge card with the words Tax advantage and numbers 1234 5678 9012 3456 and the name John Smith, with a car and buildings in the background](/images/silver-card.svg) <br />Tax Advantage Travel Card  | 5 | IBA/CBA |
 
 ### Tax Exemption Status
 Federal government travelers using GSA SmartPay IBA Travel accounts may be exempt from state taxes in select states. In addition, state tax exemption forms, official business travel documentation or a federal government identification may be required to receive state tax exemption. 

--- a/src/pages/smarttax/[...slug].astro
+++ b/src/pages/smarttax/[...slug].astro
@@ -7,9 +7,8 @@ import { getCollection } from 'astro:content';
 export async function getStaticPaths() {
   const entries = await getCollection('smarttax');
   return entries.map(entry => {
-    const slug = entry.slug == './' ? undefined : entry.slug
     return {
-      params: { slug: slug },
+      params: { slug: entry.slug },
       props: { entry, entries }
     }
   })
@@ -36,6 +35,14 @@ const { Content, headings } = await entry.render();
     )}
 
     <Content />
-</div>
+  </div>
 </PageLayout>
-    
+
+<style is:global>
+  img {
+    width: 49%;
+  }
+  table img {
+    width: 120px;
+  }
+</style>


### PR DESCRIPTION
This uses page-level css to resize images using style in template to allow the same image files to be used while still using pure markdown in the content file. It allows flexibility in sizing, while avoiding additional thumbnail downloads. The `is:global` directive will only apply to pages using this page template, however, if other smarttax pages need to layout images it will require adjusting. 