### PR TITLE
add merchant page; change side nav to allow empyty parent for custom nav

### DIFF
--- a/src/components/SideNav.astro
+++ b/src/components/SideNav.astro
@@ -10,7 +10,7 @@ pages.sort((a, b) => parseInt(a.data.order) - parseInt(b.data.order))
         <li class:list={["usa-sidenav__item", {current: id === page.id }]}>
           <a 
             class={id === page.id ? 'usa-current' : null } 
-            href={`${import.meta.env.BASE_URL}${parent_path}/${page.slug || page.id}`}
+            href={`${import.meta.env.BASE_URL}${parent_path}${page.slug || page.id}`}
           >{page.data.title}
           </a>
           <ul class="usa-sidenav__sublist">

--- a/src/content/nav/menu.yaml
+++ b/src/content/nav/menu.yaml
@@ -31,7 +31,7 @@
   - title: Card/Account Holder Responsibilities
     href: stakeholders/account-holders
 - title: Merchants
-  href: merchants/merchant-overview
+  href: merchants/
 - title: State Tax Information
   submenu:
   - title: State Tax Forms

--- a/src/pages/how-it-works/[...slug].astro
+++ b/src/pages/how-it-works/[...slug].astro
@@ -21,7 +21,7 @@ const { Content, headings } = await entry.render();
 <PageLayout title={entry.data.title}>
   <SideNav 
     title="How It Works"
-    parent_path="how-it-works"
+    parent_path="how-it-works/"
     pages={entries}
     headings={headings}
     id={entry.id}

--- a/src/pages/merchants/[...slug].astro
+++ b/src/pages/merchants/[...slug].astro
@@ -5,7 +5,7 @@ import SideNav from '../../components/SideNav.astro'
 import { getCollection } from 'astro:content';
 
 export async function getStaticPaths() {
-  const entries = await getCollection('about');
+  const entries = await getCollection('merchants');
   return entries.map(entry => {
     const slug = entry.slug == './' ? undefined : entry.slug
     return {
@@ -15,15 +15,25 @@ export async function getStaticPaths() {
   })
 }
 
+const navigation_items = [
+    {
+        slug: "faq/#merchants",
+        data: {"title": "Merchants FAQs" }
+    },
+    {
+        slug: "smarttax/recognizing-your-account",
+        data: {"title": "Recognizing Card Types" }
+    }
+]
+
 const { entry, entries } = Astro.props;
-const { Content, headings } = await entry.render();
+const { Content } = await entry.render();
 ---
 <PageLayout title={entry.data.title}>
   <SideNav 
-    title="About the GSA SmartPay Program"
-    parent_path="about/"
-    pages={entries}
-    headings={headings}
+    title="Merchants"
+    parent_path=""
+    pages={navigation_items}
     id={entry.id}
   />
   <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">

--- a/src/pages/merchants/[...slug].astro
+++ b/src/pages/merchants/[...slug].astro
@@ -26,7 +26,7 @@ const navigation_items = [
     }
 ]
 
-const { entry, entries } = Astro.props;
+const { entry } = Astro.props;
 const { Content } = await entry.render();
 ---
 <PageLayout title={entry.data.title}>

--- a/src/pages/policies-and-audits/[...slug].astro
+++ b/src/pages/policies-and-audits/[...slug].astro
@@ -18,7 +18,7 @@ export async function getStaticPaths() {
 }
 const { entry, entries, smartbulletinsData } = Astro.props;
 const { Content, headings } = await entry.render();
-const parent_path ="policies-and-audits"
+const parent_path ="policies-and-audits/"
 ---
 <PageLayout title={entry.data.title}>
   

--- a/src/pages/smarttax/[...slug].astro
+++ b/src/pages/smarttax/[...slug].astro
@@ -21,7 +21,7 @@ const { Content, headings } = await entry.render();
 <PageLayout title={entry.data.title}>
   <SideNav 
     title="State Tax Information"
-    parent_path="smarttax"
+    parent_path="smarttax/"
     pages={entries}
     headings={headings}
     id={entry.id}

--- a/src/pages/stakeholders/[...slug].astro
+++ b/src/pages/stakeholders/[...slug].astro
@@ -21,7 +21,7 @@ const { Content, headings } = await entry.render();
 <PageLayout title={entry.data.title}>
   <SideNav 
     title="Stakeholders"
-    parent_path="stakeholders"
+    parent_path="stakeholders/"
     pages={entries}
     headings={headings}
     id={entry.id}


### PR DESCRIPTION
- adds page for merchants
- changes main nav so merchant info is at `/merchants`
- changes the primary side navigation to not include the `/` between the parent path. This should now be included in the `parent` prop when using the component. This allows for cases when the parent should be empty to allow absolute paths to be passed in (as is the case with the merchant side nav) 