### PR TITLE
add a 404 not found page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -16,7 +16,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
                 <p>
                     Visit our homepage for helpful tools and resources, or contact us and we’ll point you in the right direction.
                 </p>
-                <p>
+                <p class="margin-y-3">
                     <a href={import.meta.env.BASE_URL} class="usa-button">Visit Homepage</a>
                     <a href={`${import.meta.env.BASE_URL}contact`} class="usa-button usa-button--outline">Contact Us</a>
                 </p>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,32 @@
+---
+import PageLayout from '@layouts/PageLayout.astro';
+import BaseLayout from '@layouts/BaseLayout.astro';
+---
+<BaseLayout  title="404 Not Found">
+    <section class="grid-container usa-section">
+        <div class="grid-row grid-gap flex-justify-center">
+            <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs usa-prose">
+                <h1>Page Not Found</h1>
+                <p class="usa-intro">
+                    We’re sorry, we can’t find the page you're looking for. The site administrator may have removed it, changed its location, or made it otherwise unavailable. 
+                </p>
+                <p>
+                    If you typed the URL directly, check your spelling and capitalization. Our URLs look like this: https://smartpay.gsa.gov/how-it-works.
+                </p>
+                <p>
+                    Visit our homepage for helpful tools and resources, or contact us and we’ll point you in the right direction.
+                </p>
+                <p>
+                    <a href={import.meta.env.BASE_URL} class="usa-button">Visit Homepage</a>
+                    <a href={`${import.meta.env.BASE_URL}contact`} class="usa-button usa-button--outline">Contact Us</a>
+                </p>
+                <p>
+                    For immediate assistance, email us at <a href="mailto:gsa_smartpay@gsa.gov" class="usa-link">gsa_smartpay@gsa.gov</a>.
+                </p>
+                <p class="margin-top-4 text-base-darker">
+                    <i>Error code 404</i>
+                </p>
+            </div>
+        </div>
+    </section>
+</BaseLayout>


### PR DESCRIPTION
This adds a `404.html` to the site as described in the [page documentation](https://cloud.gov/pages/documentation/customization/#pages-default-404-page). This does not seem to be working on the feature branch, but I'm not sure if that's expected on cloud.gov pages since it doesn't add the files to the root directory. If the PR looks okay, I think we should merge it so we can test on the main branch.

Here's a direct link to the 404 page:

https://federalist-ab31a10d-375d-4040-9324-1ae94e8a36b9.sites.pages.cloud.gov/preview/gsa/smartpay-website/mmeyer/140-add-404-page/404.html