### PR TITLE
Move <main> and clean up paths

### DIFF
--- a/src/components/Banner.astro
+++ b/src/components/Banner.astro
@@ -1,7 +1,7 @@
 ---
-import us_flag_small from "../assets/images/us_flag_small.png" 
-import icon_dot_gov from "../assets/images/icon-dot-gov.svg" 
-import icon_https from "../assets/images/icon-https.svg" 
+import us_flag_small from "@assets/images/us_flag_small.png" 
+import icon_dot_gov from "@assets/images/icon-dot-gov.svg" 
+import icon_https from "@assets/images/icon-https.svg" 
 
 ---
     <section

--- a/src/components/Businesslines.astro
+++ b/src/components/Businesslines.astro
@@ -1,9 +1,9 @@
 ---
-import redcard from "../assets/images/red-card.svg"
-import bluecard from "../assets/images/blue-card.svg"
-import silvercard from "../assets/images/silver-card.svg"
-import greencard from "../assets/images/green-card.svg"
-import yellowcard from "../assets/images/yellow-card.svg"
+import redcard from "@assets/images/red-card.svg"
+import bluecard from "@assets/images/blue-card.svg"
+import silvercard from "@assets/images/silver-card.svg"
+import greencard from "@assets/images/green-card.svg"
+import yellowcard from "@assets/images/yellow-card.svg"
 ---
 <section class="usa-graphic-list usa-section usa-section--dark">
   <div class="grid-container">

--- a/src/components/Callout.astro
+++ b/src/components/Callout.astro
@@ -1,7 +1,7 @@
 ---
-import callout_889 from '../assets/images/callout_889.svg'
-import callout_map from '../assets/images/callout_map.svg'
-import callout_forum from '../assets/images/callout_forum.svg'
+import callout_889 from '@assets/images/callout_889.svg'
+import callout_map from '@assets/images/callout_map.svg'
+import callout_forum from '@assets/images/callout_forum.svg'
 ---
 <section class="sp_callout">
     <div class="grid-container margin-y-6">

--- a/src/components/GSAHeader.astro
+++ b/src/components/GSAHeader.astro
@@ -1,7 +1,7 @@
 ---
-import GSALogo from '../assets/images/gsa-smartpay-program-logo.svg'
-import searchIcon from "../assets/images/usa-icons/search--white.svg"
-import PrimaryMenu from './PrimaryMenu.astro';
+import GSALogo from '@assets/images/gsa-smartpay-program-logo.svg'
+import searchIcon from "@assets/images/usa-icons/search--white.svg"
+import PrimaryMenu from '@components/PrimaryMenu.astro';
 ---
 <header class="usa-header usa-header--extended">
   <div class="usa-navbar">

--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -1,5 +1,5 @@
 ---
-const { text, link, parent_nav_path } = Astro.props;
+const { text, link } = Astro.props;
 const isInternal = link.includes("http")? false: true
 ---
 {isInternal? <a href={`${import.meta.env.BASE_URL}${link}`} class="usa-button">{text}</a>:<a href={link} class="usa-button">{text}</a>}

--- a/src/components/PrimaryMenu.astro
+++ b/src/components/PrimaryMenu.astro
@@ -1,6 +1,6 @@
 ---
-import PrimaryMenuItem from './PrimaryMenuItem.astro';
-import closeIcon from '../assets/images/usa-icons/close.svg'
+import PrimaryMenuItem from '@components/PrimaryMenuItem.astro';
+import closeIcon from '@assets/images/usa-icons/close.svg'
 
 import { getEntry } from 'astro:content';
 const menuData = await getEntry('nav', 'menu');

--- a/src/components/SinglePageSideNav.astro
+++ b/src/components/SinglePageSideNav.astro
@@ -1,6 +1,6 @@
 ---
+import TopNav from "@components/TopNav.astro";
 const {headings, title, parent_nav_path, parent_nav_text} = Astro.props;
-import TopNav from "./TopNav.astro";
 ---
 <div class="usa-layout-docs__sidenav desktop:grid-col-4">
   { parent_nav_path && parent_nav_text && (

--- a/src/components/TopNav.astro
+++ b/src/components/TopNav.astro
@@ -1,6 +1,7 @@
 ---
+import previousNavIcon from '@assets/images/previous-nav-icon.svg'
+
 const { parent_nav_path, parent_nav_text} = Astro.props;
-import previousNavIcon from '../assets/images/previous-nav-icon.svg'
 const url = `${import.meta.env.BASE_URL}${parent_nav_path}`
 
 ---

--- a/src/components/USAIdentifier.astro
+++ b/src/components/USAIdentifier.astro
@@ -1,5 +1,5 @@
 ---
-import gsa_logo from '../assets/images/gsa-logo.svg'
+import gsa_logo from '@assets/images/gsa-logo.svg'
 ---
 
     <div class="usa-identifier">

--- a/src/content/audits/2014-va-purchase.mdx
+++ b/src/content/audits/2014-va-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - VA
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.va.gov/oig/pubs/VAOIG-13-02267-124.pdf" text="View Full Audit" />
 

--- a/src/content/audits/2015-gao-purchase.mdx
+++ b/src/content/audits/2015-gao-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - GAO
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.gao.gov/products/OIG-15-2" text="View Full Audit" />
 

--- a/src/content/audits/2016-dhs-purchase.mdx
+++ b/src/content/audits/2016-dhs-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - DHS
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.oversight.gov/report/dhs/fiscal-year-2015-risk-assessment-dhs-bank-card-program-indicates-moderate-risk" text="View Full Audit" />
 

--- a/src/content/audits/2016-dod-travel.mdx
+++ b/src/content/audits/2016-dod-travel.mdx
@@ -10,7 +10,7 @@ tags:
   - DOD
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.dodig.mil/Reports/Compendium-of-Open-Recommendations/Article/1119310/dod-officials-did-not-take-appropriate-action-when-notified-of-potential-travel/" text="View Full Audit" />
 

--- a/src/content/audits/2016-doi-purchase-fleet.mdx
+++ b/src/content/audits/2016-doi-purchase-fleet.mdx
@@ -10,7 +10,7 @@ tags:
   - DOI
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.doioig.gov/reports/audit/us-department-interiors-internal-controls-purchase-cards-and-fleet-cards-0" text="View Full Audit" />
 

--- a/src/content/audits/2016-epa-travel.mdx
+++ b/src/content/audits/2016-epa-travel.mdx
@@ -10,7 +10,7 @@ tags:
   - EPA
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.epa.gov/office-inspector-general/report-epa-oversight-travel-cards-needs-improve" text="View Full Audit" />
 

--- a/src/content/audits/2016-gao-purchase.mdx
+++ b/src/content/audits/2016-gao-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - GAO
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.gao.gov/products/GAO-16-526" text="View Full Audit" />
 

--- a/src/content/audits/2016-gao-travel.mdx
+++ b/src/content/audits/2016-gao-travel.mdx
@@ -10,7 +10,7 @@ tags:
   - GAO
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.gao.gov/products/GAO-16-657" text="View Full Audit" />
 

--- a/src/content/audits/2017-epa-purchase.mdx
+++ b/src/content/audits/2017-epa-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - EPA
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.epa.gov/office-inspector-general/report-risk-epas-fiscal-year-2016-purchase-card-and-convenience-check" text="View Full Audit" />
 

--- a/src/content/audits/2017-gao-purchase.mdx
+++ b/src/content/audits/2017-gao-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - GAO
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.gao.gov/products/GAO-17-276" text="View Full Audit" />
 

--- a/src/content/audits/2017-ssa-purchase.mdx
+++ b/src/content/audits/2017-ssa-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - SSA
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="files/audits/2017-ssa-purchase.pdf" text="View Full Audit" />
 

--- a/src/content/audits/2017-usps-fleet.mdx
+++ b/src/content/audits/2017-usps-fleet.mdx
@@ -10,7 +10,7 @@ tags:
   - USPS
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.uspsoig.gov/reports/audit-reports/fleet-specialty-credit-cards-eastern-area" text="View Full Audit" />
 

--- a/src/content/audits/2017-va-purchase.mdx
+++ b/src/content/audits/2017-va-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - VA
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.oversight.gov/report/va/review-alleged-irregular-use-purchase-cards-vha%E2%80%99s-engineering-service-carl-vinson-va" text="View Full Audit" />
 

--- a/src/content/audits/2018-cigie-purchase.mdx
+++ b/src/content/audits/2018-cigie-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - CIGIE
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://oversight.gov/report/cigie/report-government-purchase-card-initiative" text="View Full Audit" />
 

--- a/src/content/audits/2018-dod-purchase-travel.mdx
+++ b/src/content/audits/2018-dod-purchase-travel.mdx
@@ -10,7 +10,7 @@ tags:
   - DOD
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.dodig.mil/reports.html/Article/1485315/dod-reporting-of-charge-card-misuse-to-omb/" text="View Full Audit" />
 

--- a/src/content/audits/2018-dos.mdx
+++ b/src/content/audits/2018-dos.mdx
@@ -10,7 +10,7 @@ tags:
   - CIGIE
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.oversight.gov/report/dos/inspector-general-statement-department-state%E2%80%99s-major-management-and-performance" text="View Full Audit" />
 

--- a/src/content/audits/2018-gao.mdx
+++ b/src/content/audits/2018-gao.mdx
@@ -10,7 +10,7 @@ tags:
   - GAO
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.gao.gov/products/GAO-18-371SP" text="View Full Audit" />
 

--- a/src/content/audits/2019-amtrak-purchase.mdx
+++ b/src/content/audits/2019-amtrak-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - Amtrak
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://amtrakoig.gov/sites/default/files/reports/OIG-A-2019-013%20Controls%20Over%20PCards.pdf" text="View Full Audit" />
 

--- a/src/content/audits/2019-dod-air-force-purchase.mdx
+++ b/src/content/audits/2019-dod-air-force-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - DOD
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.dodig.mil/reports.html/Article/1938309/audit-of-the-air-force-nonappropriated-fund-government-purchase-card-program-do/" text="View Full Audit" />
 

--- a/src/content/audits/2019-dod-purchase.mdx
+++ b/src/content/audits/2019-dod-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - DOD
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.dodig.mil/reports.html/Article/1920236/audit-of-the-dods-management-of-the-cybersecurity-risks-for-government-purchase/" text="View Full Audit" />
 

--- a/src/content/audits/2019-dod-travel.mdx
+++ b/src/content/audits/2019-dod-travel.mdx
@@ -10,7 +10,7 @@ tags:
   - DOD
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="files/audits/2019-dod-travel.pdf" text="View Full Audit" />
 

--- a/src/content/audits/2019-doi-purchase.mdx
+++ b/src/content/audits/2019-doi-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - DOI
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="files/audits/2019-doi-purchase.pdf" text="View Full Audit" />
 

--- a/src/content/audits/2019-gsa-purchase.mdx
+++ b/src/content/audits/2019-gsa-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - GSA
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="files/audits/2019-gsa-purchase.pdf" text="View Full Audit" />
 

--- a/src/content/audits/2019-gsa-travel.mdx
+++ b/src/content/audits/2019-gsa-travel.mdx
@@ -10,7 +10,7 @@ tags:
   - GSA
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="files/audits/2019-gsa-travel.pdf" text="View Full Audit" />
 

--- a/src/content/audits/2019-nsa-travel.mdx
+++ b/src/content/audits/2019-nsa-travel.mdx
@@ -10,7 +10,7 @@ tags:
   - NSA
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.oversight.gov/report/nsa/audit-agency%E2%80%99s-travel-program" text="View Full Audit" />
 

--- a/src/content/audits/2020-dot-purchase.mdx
+++ b/src/content/audits/2020-dot-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - DOT
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="https://www.oig.dot.gov/library-item/37777" text="View Full Audit" />
 

--- a/src/content/audits/2020-gao-disaster-response.mdx
+++ b/src/content/audits/2020-gao-disaster-response.mdx
@@ -10,7 +10,7 @@ tags:
   - GAO
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="files/audits/2020-gao-disaster-response.pdf" text="View Full Audit" />
 

--- a/src/content/audits/2020-hud-purchase.mdx
+++ b/src/content/audits/2020-hud-purchase.mdx
@@ -10,7 +10,7 @@ tags:
   - HUD
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="files/audits/2020-hud-purchase.pdf" text="View Full Audit" />
 

--- a/src/content/audits/2020-hud-travel.mdx
+++ b/src/content/audits/2020-hud-travel.mdx
@@ -10,7 +10,7 @@ tags:
   - HUD
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="files/audits/2020-hud-travel.pdf" text="View Full Audit" />
 

--- a/src/content/audits/2020-sec-travel.mdx
+++ b/src/content/audits/2020-sec-travel.mdx
@@ -10,7 +10,7 @@ tags:
   - SEC
 ---
 
-import LinkButton from '../../components/LinkButton.astro';
+import LinkButton from '@components/LinkButton.astro';
 
 <LinkButton link="files/audits/2020-sec-travel.pdf" text="View Full Audit" />
 

--- a/src/content/faq/faq.mdx
+++ b/src/content/faq/faq.mdx
@@ -3,7 +3,7 @@ title: Frequently Asked Questions
 order: 1
 
 ---
-import Accordion from '../../components/Accordion.astro';
+import Accordion from '@components/Accordion.astro';
 
 
 ## State Tax

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,8 +1,7 @@
 ---
-import GSAHeader from '../components/GSAHeader.astro';
-import USAIdentifier from '../components/USAIdentifier.astro';
-import Banner from '../components/Banner.astro';
-
+import GSAHeader from '@components/GSAHeader.astro';
+import USAIdentifier from '@components/USAIdentifier.astro';
+import Banner from '@components/Banner.astro';
 
 const { title } = Astro.props;
 ---
@@ -28,9 +27,9 @@ const { title } = Astro.props;
       <Banner />
       <div class="background flex-fill">
         <GSAHeader />
-        <main id="main-content" class="wide-layout">
+        <div class="border-top-1px border-base-lightest wide-layout">
           <slot />
-        </main>
+        </div>
       </div>
       <USAIdentifier /> 
     </div>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from "./BaseLayout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
 const { title } = Astro.props;
 ---
 <BaseLayout title={title}>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,32 +1,31 @@
 ---
-import PageLayout from '@layouts/PageLayout.astro';
 import BaseLayout from '@layouts/BaseLayout.astro';
 ---
 <BaseLayout  title="404 Not Found">
-    <section class="grid-container usa-section">
-        <div class="grid-row grid-gap flex-justify-center">
-            <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs usa-prose">
-                <h1>Page Not Found</h1>
-                <p class="usa-intro">
-                    We’re sorry, we can’t find the page you're looking for. The site administrator may have removed it, changed its location, or made it otherwise unavailable. 
-                </p>
-                <p>
-                    If you typed the URL directly, check your spelling and capitalization. Our URLs look like this: https://smartpay.gsa.gov/how-it-works.
-                </p>
-                <p>
-                    Visit our homepage for helpful tools and resources, or contact us and we’ll point you in the right direction.
-                </p>
-                <p class="margin-y-3">
-                    <a href={import.meta.env.BASE_URL} class="usa-button">Visit Homepage</a>
-                    <a href={`${import.meta.env.BASE_URL}contact`} class="usa-button usa-button--outline">Contact Us</a>
-                </p>
-                <p>
-                    For immediate assistance, email us at <a href="mailto:gsa_smartpay@gsa.gov" class="usa-link">gsa_smartpay@gsa.gov</a>.
-                </p>
-                <p class="margin-top-4 text-base-darker">
-                    <i>Error code 404</i>
-                </p>
-            </div>
-        </div>
-    </section>
+  <section class="grid-container usa-section">
+    <div class="grid-row grid-gap flex-justify-center">
+      <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs usa-prose">
+        <h1>Page Not Found</h1>
+        <p class="usa-intro">
+          We’re sorry, we can’t find the page you're looking for. The site administrator may have removed it, changed its location, or made it otherwise unavailable. 
+        </p>
+        <p>
+          If you typed the URL directly, check your spelling and capitalization. Our URLs look like this: https://smartpay.gsa.gov/how-it-works.
+        </p>
+        <p>
+          Visit our homepage for helpful tools and resources, or contact us and we’ll point you in the right direction.
+        </p>
+        <p class="margin-y-3">
+          <a href={import.meta.env.BASE_URL} class="usa-button">Visit Homepage</a>
+          <a href={`${import.meta.env.BASE_URL}contact`} class="usa-button usa-button--outline">Contact Us</a>
+        </p>
+        <p>
+          For immediate assistance, email us at <a href="mailto:gsa_smartpay@gsa.gov" class="usa-link">gsa_smartpay@gsa.gov</a>.
+        </p>
+        <p class="margin-top-4 text-base-darker">
+          <i>Error code 404</i>
+        </p>
+      </main>
+    </div>
+  </section>
 </BaseLayout>

--- a/src/pages/about/[...slug].astro
+++ b/src/pages/about/[...slug].astro
@@ -1,6 +1,6 @@
 ---
-import PageLayout from '../../layouts/PageLayout.astro';
-import SideNav from '../../components/SideNav.astro'
+import PageLayout from '@layouts/PageLayout.astro';
+import SideNav from '@components/SideNav.astro'
 
 import { getCollection } from 'astro:content';
 
@@ -26,7 +26,7 @@ const { Content, headings } = await entry.render();
     headings={headings}
     id={entry.id}
   />
-  <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
+  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
     <h1>{ entry.data.title }</h1>
 
     { entry.data.intro && ( 
@@ -36,6 +36,6 @@ const { Content, headings } = await entry.render();
     )}
 
     <Content />
-</div>
+    </main>
 </PageLayout>
     

--- a/src/pages/contact/[...slug].astro
+++ b/src/pages/contact/[...slug].astro
@@ -24,7 +24,7 @@ const { Content, headings } = await entry.render();
       headings={headings}
       id={entry.id}
     />
-  <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
+  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
     <h1>{ entry.data.title }</h1>
 
     { entry.data.intro && ( 
@@ -34,6 +34,6 @@ const { Content, headings } = await entry.render();
     )}
 
     <Content />
-</div>
+    </main>
 </PageLayout>
     

--- a/src/pages/faq/index.astro
+++ b/src/pages/faq/index.astro
@@ -29,10 +29,10 @@ for(const heading of headings){
   title="Frequently Asked Questions"
   headings ={newHeadings}
   />
-  <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
+  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
     <h1>Frequently Asked Questions</h1>
     <Content />
-  </div>
+  </main>
 </PageLayout>
 <script >
   import {handleAccordionSearch} from "../../assets/js/faqHelper.js"

--- a/src/pages/how-it-works/[...slug].astro
+++ b/src/pages/how-it-works/[...slug].astro
@@ -1,6 +1,6 @@
 ---
-import PageLayout from '../../layouts/PageLayout.astro';
-import SideNav from '../../components/SideNav.astro'
+import PageLayout from '@layouts/PageLayout.astro';
+import SideNav from '@components/SideNav.astro'
 
 import { getCollection } from 'astro:content';
 
@@ -26,7 +26,7 @@ const { Content, headings } = await entry.render();
     headings={headings}
     id={entry.id}
   />
-  <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
+  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
     <h1>{ entry.data.title }</h1>
 
     { entry.data.intro && ( 
@@ -36,6 +36,6 @@ const { Content, headings } = await entry.render();
     )}
 
     <Content />
-</div>
+  </main>
 </PageLayout>
     

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,23 +1,22 @@
 ---
-import BaseLayout from "../layouts/BaseLayout.astro";
-import Hero from "../components/Hero.astro"
-import hero_image from "../assets/images/smartpay_website_hero.jpg"
-import Businesslines from '../components/Businesslines.astro';
-import Callout from "../components/Callout.astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
+import Hero from "@components/Hero.astro"
+import hero_image from "@assets/images/smartpay_website_hero.jpg"
+import Businesslines from '@components/Businesslines.astro';
+import Callout from "@components/Callout.astro";
 
 ---
 <BaseLayout title="GSA SmartPay">
 	<Hero  hero_image={hero_image}>
-        GSA SmartPay
-        <span slot="subheader">
-            The GSA SmartPay Program is the largest government charge card and commercial payment solutions program in the world.
-        </span>
+    GSA SmartPay
+    <span slot="subheader">
+      The GSA SmartPay Program is the largest government charge card and commercial payment solutions program in the world.
+    </span>
 		<div slot ="linkbutton" class="display-flex">
-            <a class="usa-button" href={`${import.meta.env.BASE_URL}about/`}>Find out more</a>
-            <a class="usa-button usa-button--outline" href={`${import.meta.env.BASE_URL}about/benefits`}>Benefits</a>
-        </div>
+      <a class="usa-button" href={`${import.meta.env.BASE_URL}about/`}>Find out more</a>
+      <a class="usa-button usa-button--outline" href={`${import.meta.env.BASE_URL}about/benefits`}>Benefits</a>
+    </div>
     </Hero>
     <Callout />
     <Businesslines />
-
 </BaseLayout>

--- a/src/pages/merchants/[...slug].astro
+++ b/src/pages/merchants/[...slug].astro
@@ -1,6 +1,6 @@
 ---
-import PageLayout from '../../layouts/PageLayout.astro';
-import SideNav from '../../components/SideNav.astro'
+import PageLayout from '@layouts/PageLayout.astro';
+import SideNav from '@components/SideNav.astro'
 
 import { getCollection } from 'astro:content';
 
@@ -36,7 +36,7 @@ const { Content } = await entry.render();
     pages={navigation_items}
     id={entry.id}
   />
-  <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
+  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
     <h1>{ entry.data.title }</h1>
 
     { entry.data.intro && ( 
@@ -46,6 +46,6 @@ const { Content } = await entry.render();
     )}
 
     <Content />
-</div>
+    </main>
 </PageLayout>
     

--- a/src/pages/policies-and-audits/[...slug].astro
+++ b/src/pages/policies-and-audits/[...slug].astro
@@ -1,12 +1,11 @@
 ---
-import PageLayout from '../../layouts/PageLayout.astro';
-import SideNav from '../../components/SideNav.astro'
+import PageLayout from '@layouts/PageLayout.astro';
+import SideNav from '@components/SideNav.astro'
 
 import { getCollection, getEntry } from 'astro:content';
 
 export async function getStaticPaths() {
   const entries = await getCollection('policies-and-audits');
-  //console.log(entries)
   const smartbulletinsData = await getEntry('smartbulletins', 'smart-bulletins');
 
   return entries.map(entry => {
@@ -21,7 +20,6 @@ const { Content, headings } = await entry.render();
 const parent_path ="policies-and-audits/"
 ---
 <PageLayout title={entry.data.title}>
-  
   <SideNav 
     title="Policies & Audits"
     parent_path={parent_path}
@@ -29,7 +27,7 @@ const parent_path ="policies-and-audits/"
     headings={headings}
     id={entry.id}
   />
-  <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
+  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
     <h1>{ entry.data.title }</h1>
 
     { entry.data.intro && ( 
@@ -39,6 +37,6 @@ const parent_path ="policies-and-audits/"
     )}
 
     <Content />
-</div>
+  </main>
 </PageLayout>
     

--- a/src/pages/policies-and-audits/audits/[...slug].astro
+++ b/src/pages/policies-and-audits/audits/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
-import PageLayout from '../../../layouts/PageLayout.astro';
-import SideNav from '../../../components/SinglePageSideNav.astro'
+import PageLayout from '@layouts/PageLayout.astro';
+import SideNav from '@components/SinglePageSideNav.astro'
 export async function getStaticPaths() {
   const entries = await getCollection('audits');
   return entries.map(entry => {
@@ -13,19 +13,17 @@ export async function getStaticPaths() {
 }
 const { entry} = Astro.props;
 const { Content, headings } = await entry.render();
-
 ---
 
 <PageLayout title ={entry.data.title} >
-      <SideNav 
-      title={entry.data.title}
-      headings ={headings}
-      parent_nav_path="policies-and-audits/audits"
-      parent_nav_text = "Return to the Audit Repository" 
-      />
-      <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
-        <h1>{entry.data.title}</h1>
-        <Content />
-      </div>
-    </div>
+  <SideNav 
+    title={entry.data.title}
+    headings ={headings}
+    parent_nav_path="policies-and-audits/audits"
+    parent_nav_text = "Return to the Audit Repository" 
+  />
+  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
+    <h1>{entry.data.title}</h1>
+    <Content />
+  </main>
 </PageLayout>

--- a/src/pages/policies-and-audits/smart-bulletins/index.astro
+++ b/src/pages/policies-and-audits/smart-bulletins/index.astro
@@ -1,12 +1,13 @@
 ---
 import { getEntry } from 'astro:content';
-import PageLayout from '../../../layouts/PageLayout.astro';
-import TopNav from '../../../components/TopNav.astro'
+import PageLayout from '@layouts/PageLayout.astro';
+import TopNav from '@components/TopNav.astro'
 const smartbulletinsData = await getEntry('smartbulletins', 'smart-bulletins');
 ---
 <PageLayout title={smartbulletinsData.data.title}>
-    <div>
-     <TopNav parent_nav_path={smartbulletinsData.data.parent_nav_path} parent_nav_text = {`Return to the ${smartbulletinsData.data.parent_nav_text}`} />
+  <div>
+    <TopNav parent_nav_path={smartbulletinsData.data.parent_nav_path} parent_nav_text = {`Return to the ${smartbulletinsData.data.parent_nav_text}`} />
+    <main id="main-content">
       <h1>{smartbulletinsData.data.title}</h1>
       <p class="usa-intro">{smartbulletinsData.data.into}</p>
       <!--smart buletins table -->
@@ -21,20 +22,19 @@ const smartbulletinsData = await getEntry('smartbulletins', 'smart-bulletins');
           </tr>
         </thead>
         <tbody>
-         { smartbulletinsData.data.bulletins.map(item=>(
+          { smartbulletinsData.data.bulletins.map(item => (
             <tr>
-            <th scope="row" class="grid-col-1">{item.number}</th>
-            <td>
-             <a href={`${import.meta.env.BASE_URL}files/smartbulletins/${item.filename}`}>{item.title}</a> 
-            </td>
-            <td class="grid-col-2">{item.audience}</td>
-            <td class="grid-col-2">{item.published}</td>
-            <td class="grid-col-2">{item.lastupdated}</td>
-          </tr>
-
-         ))}
-          
+              <th scope="row" class="grid-col-1">{item.number}</th>
+              <td>
+                <a href={`${import.meta.env.BASE_URL}files/smartbulletins/${item.filename}`}>{item.title}</a> 
+              </td>
+              <td class="grid-col-2">{item.audience}</td>
+              <td class="grid-col-2">{item.published}</td>
+              <td class="grid-col-2">{item.lastupdated}</td>
+            </tr>
+          ))}
         </tbody>
       </table>
-    </div>
+    </main>
+  </div>
 </PageLayout>

--- a/src/pages/resources/[...slug].astro
+++ b/src/pages/resources/[...slug].astro
@@ -1,8 +1,8 @@
 ---
-import PageLayout from '../../layouts/PageLayout.astro';
-import SideNav from '../../components/SideNav.astro'
+import PageLayout from '@layouts/PageLayout.astro';
+import SideNav from '@components/SideNav.astro'
 
-import { getCollection, getEntryBySlug } from 'astro:content';
+import { getCollection } from 'astro:content';
 
 export async function getStaticPaths() {
   const entries = await getCollection('resources');
@@ -25,7 +25,7 @@ const { Content, headings } = await entry.render();
     headings={headings}
     id={entry.id}
   />
-  <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
+  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
     <h1>{ entry.data.title }</h1>
 
     { entry.data.intro && ( 
@@ -33,8 +33,7 @@ const { Content, headings } = await entry.render();
         { entry.data.intro }
       </p>
     )}
-
     <Content />
-</div>
+  </main>
 </PageLayout>
     

--- a/src/pages/resources/publications/[...slug].astro
+++ b/src/pages/resources/publications/[...slug].astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
-import PageLayout from '../../../layouts/PageLayout.astro';
+import PageLayout from '@layouts/PageLayout.astro';
 import TopNav from '@components/TopNav.astro';
 export async function getStaticPaths() {
   const entries = await getCollection('publications');
@@ -13,15 +13,12 @@ export async function getStaticPaths() {
 }
 const { entry} = Astro.props;
 const { Content} = await entry.render();
-
 ---
-
 <PageLayout title ={entry.data.title} >
   <TopNav parent_nav_path="resources/publications" parent_nav_text = "Return to the Publications and Videos" />
-      <div class="usa-layout-docs__main usa-prose usa-layout-docs">
-        <h1>{entry.data.title}</h1>
-        <p class="usa-intro">{entry.data.intro}</p>
-        <Content />
-      </div>
-    </div>
+  <main id="main-content" class="usa-layout-docs__main usa-prose usa-layout-docs">
+    <h1>{entry.data.title}</h1>
+    <p class="usa-intro">{entry.data.intro}</p>
+    <Content />
+  </main>
 </PageLayout>

--- a/src/pages/smarttax/[...slug].astro
+++ b/src/pages/smarttax/[...slug].astro
@@ -1,6 +1,6 @@
 ---
-import PageLayout from '../../layouts/PageLayout.astro';
-import SideNav from '../../components/SideNav.astro'
+import PageLayout from '@layouts/PageLayout.astro';
+import SideNav from '@components/SideNav.astro'
 
 import { getCollection } from 'astro:content';
 
@@ -25,7 +25,7 @@ const { Content, headings } = await entry.render();
     headings={headings}
     id={entry.id}
   />
-  <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
+  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
     <h1>{ entry.data.title }</h1>
 
     { entry.data.intro && ( 
@@ -35,7 +35,7 @@ const { Content, headings } = await entry.render();
     )}
 
     <Content />
-  </div>
+  </main>
 </PageLayout>
 
 <style is:global>

--- a/src/pages/smarttax/state-tax-forms/[slug].astro
+++ b/src/pages/smarttax/state-tax-forms/[slug].astro
@@ -30,7 +30,7 @@ const { Content, headings } = await entry.render();
     parent_nav_path = "smarttax/state-tax-forms"
     parent_nav_text = "Return to State Tax Forms"
   />
-  <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
+  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
     <h1>{ entry.data.name } Tax Information</h1>
     <StateTaxSelection 
       current_state={entry.data.name}
@@ -46,6 +46,6 @@ const { Content, headings } = await entry.render();
     <p class="margin-top-3 text-base-darker">
       <i>Updated {format_date(entry.data.updated)}</i>
     </p>
-</div>
+  </main>
 </PageLayout>
     

--- a/src/pages/stakeholders/[...slug].astro
+++ b/src/pages/stakeholders/[...slug].astro
@@ -1,6 +1,6 @@
 ---
-import PageLayout from '../../layouts/PageLayout.astro';
-import SideNav from '../../components/SideNav.astro'
+import PageLayout from '@layouts/PageLayout.astro';
+import SideNav from '@components/SideNav.astro'
 
 import { getCollection } from 'astro:content';
 
@@ -26,7 +26,7 @@ const { Content, headings } = await entry.render();
     headings={headings}
     id={entry.id}
   />
-  <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
+  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
     <h1>{ entry.data.title }</h1>
 
     { entry.data.intro && ( 
@@ -36,6 +36,6 @@ const { Content, headings } = await entry.render();
     )}
 
     <Content />
-</div>
+  </main>
 </PageLayout>
     


### PR DESCRIPTION
Per #155 

- Move `<main  id=main-content>` to only encompass the content to allow screen readers to jump to main content.
-  Change `../../` style paths to `@component/` style paths everywhere. 
- Some general tidying up

This should produce _no_ visible changes to the site.