### PR TITLE
Update IBA/CBA account link on state taxes

### DIFF
--- a/src/components/StateTaxSummaryList.astro
+++ b/src/components/StateTaxSummaryList.astro
@@ -7,7 +7,7 @@ const icon_colors = {
   'error_outline': 'text-warning-darker'
 }
 
-const add_link = items.some(({text}) => text.includes('(IBA)') || text.includes('(CBA)'));
+const explains_iba_ibc = items.some(({text}) => text.includes('(IBA)')) &&  items.some(({text}) => text.includes('(CBA)'));
 ---
 
 <div class="bg-base-lightest padding-2">
@@ -23,9 +23,16 @@ const add_link = items.some(({text}) => text.includes('(IBA)') || text.includes(
       </li>
       ))}
     </ul>
-    {add_link && (
-    <p class="margin-bottom-0">
-      <a class="usa-link" href={`${import.meta.env.BASE_URL}smarttax/recognizing-your-account`}>Need help recognizing a card or telling if a card is an IBA or CBA?</a>
-    </p>
-    )}
+    {explains_iba_ibc 
+    ? (
+      <p class="margin-bottom-0">
+        <a class="usa-link" href={`${import.meta.env.BASE_URL}smarttax/recognizing-your-account`}>Need help recognizing a card or telling if a card is an IBA or CBA?</a>
+      </p>
+    )
+    : (
+      <p class="margin-bottom-0">
+        <a class="usa-link" href={`${import.meta.env.BASE_URL}smarttax/recognizing-your-account`}>Need help recognizing a card or telling if a card is an individually billed account (IBA) or a centrally billed account (CBA)?</a>
+      </p>
+    )  
+  }
   </div>

--- a/src/components/StateTaxSummaryList.astro
+++ b/src/components/StateTaxSummaryList.astro
@@ -7,7 +7,7 @@ const icon_colors = {
   'error_outline': 'text-warning-darker'
 }
 
-const explains_iba_ibc = items.some(({text}) => text.includes('(IBA)')) &&  items.some(({text}) => text.includes('(CBA)'));
+const explains_iba_cba = items.some(({text}) => text.includes('(IBA)')) &&  items.some(({text}) => text.includes('(CBA)'));
 ---
 
 <div class="bg-base-lightest padding-2">
@@ -23,7 +23,7 @@ const explains_iba_ibc = items.some(({text}) => text.includes('(IBA)')) &&  item
       </li>
       ))}
     </ul>
-    {explains_iba_ibc 
+    {explains_iba_cba 
     ? (
       <p class="margin-bottom-0">
         <a class="usa-link" href={`${import.meta.env.BASE_URL}smarttax/recognizing-your-account`}>Need help recognizing a card or telling if a card is an IBA or CBA?</a>


### PR DESCRIPTION
Add link explaining CBA and IBA to all states even when the summary does not include CBA/IBA language.

When the summary doesn't contain either the IBA of CBA, then spell these out in the link. For example Alaska and New Hampshire should both have a link that spells out what IBA and CBA means, but other states should just use the plain acronym. 