### PR TITLE
Add the main element to the index page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import Callout from "@components/Callout.astro";
 
 ---
 <BaseLayout title="GSA SmartPay">
+  <main id="main-content">
 	<Hero  hero_image={hero_image}>
     GSA SmartPay
     <span slot="subheader">
@@ -19,4 +20,5 @@ import Callout from "@components/Callout.astro";
     </Hero>
     <Callout />
     <Businesslines />
+  </main>
 </BaseLayout>


### PR DESCRIPTION
Adds the <main> element to the index page to the screen reader link navigates past the menu. For #155 