### PR TITLE
Fix inconsistent size on smart bulletin h1

### DIFF
--- a/src/content/smartbulletins/smart-bulletins.yaml
+++ b/src/content/smartbulletins/smart-bulletins.yaml
@@ -1,5 +1,5 @@
 title: Smart Bulletins
-into: Smart Bulletins keep customer agencies and stakeholders informed of new or updated policies, regulations, program management practices, and other developments.
+intro: Smart Bulletins keep customer agencies and stakeholders informed of new or updated policies, regulations, program management practices, and other developments.
 parent_nav_text: Polices & Audits
 parent_nav_path: policies-and-audits
 order: 2

--- a/src/pages/policies-and-audits/[...slug].astro
+++ b/src/pages/policies-and-audits/[...slug].astro
@@ -24,8 +24,10 @@ const parent_path ="policies-and-audits/"
   {entry.data.nosidenav? 
   <TopNav parent_nav_path="policies-and-audits" parent_nav_text = "Return to the Policies & Audits" />
    
-  <main id="main-content" class="usa-layout-docs__main  usa-prose usa-layout-docs">
-    <h1>{ entry.data.title }</h1>
+  <main id="main-content">
+    <div class="usa-prose">
+      <h1>{ entry.data.title }</h1>
+    </div>
     { entry.data.intro && ( 
       <p class="usa-intro">
         { entry.data.intro }

--- a/src/pages/policies-and-audits/smart-bulletins/index.astro
+++ b/src/pages/policies-and-audits/smart-bulletins/index.astro
@@ -7,7 +7,7 @@ const smartbulletinsData = await getEntry('smartbulletins', 'smart-bulletins');
 <PageLayout title={smartbulletinsData.data.title}>
   <div>
     <TopNav parent_nav_path={smartbulletinsData.data.parent_nav_path} parent_nav_text = {`Return to the ${smartbulletinsData.data.parent_nav_text}`} />
-    <main id="main-content">
+    <main id="main-content" class="usa-layout-docs__main  usa-prose usa-layout-docs">
       <h1>{smartbulletinsData.data.title}</h1>
       <p class="usa-prose usa-intro">{smartbulletinsData.data.into}</p>
       <!--smart buletins table -->

--- a/src/pages/policies-and-audits/smart-bulletins/index.astro
+++ b/src/pages/policies-and-audits/smart-bulletins/index.astro
@@ -7,9 +7,11 @@ const smartbulletinsData = await getEntry('smartbulletins', 'smart-bulletins');
 <PageLayout title={smartbulletinsData.data.title}>
   <div>
     <TopNav parent_nav_path={smartbulletinsData.data.parent_nav_path} parent_nav_text = {`Return to the ${smartbulletinsData.data.parent_nav_text}`} />
-    <main id="main-content" class="usa-layout-docs__main  usa-prose usa-layout-docs">
-      <h1>{smartbulletinsData.data.title}</h1>
-      <p class="usa-prose usa-intro">{smartbulletinsData.data.into}</p>
+    <main id="main-content">
+      <div class="usa-prose">
+        <h1>{smartbulletinsData.data.title}</h1>
+      </div>
+      <p class="usa-prose usa-intro">{smartbulletinsData.data.intro}</p>
       <!--smart buletins table -->
       <table class="usa-table usa-table--borderless">
         <thead>


### PR DESCRIPTION
- The Smart Bulletins `h1` is smaller than `h1`s on other pages
  - The `h1` on Smart Bulletins is styled at `2em`, while those on other pages are styled at `2.44rem`

- This appears to be caused by the Smart Bulletins astro layout lacking `usa-prose` classes on the `main` element that the other pages have
- This PR adds the `main` classes to fix the inconsistent font size

## Policies page
![Screenshot showing Policies title and a table](https://github.com/GSA/smartpay-website/assets/32855580/f0e8d0a9-1459-48b8-ad24-cbaef5134744)

## Smart Bulletins page
![Screenshot showing Smart Bulletins page title and a table](https://github.com/GSA/smartpay-website/assets/32855580/b8fb91cf-9d1d-4e81-8d02-93575790fcfa)
