### PR TITLE
Minor content edit to purchase publications

### DIFF
--- a/src/content/publications/purchase.mdx
+++ b/src/content/publications/purchase.mdx
@@ -16,7 +16,7 @@ export const components = {table: TableBorderless, th: TableHeaderBorderless, td
 
 Title | Description | Audience | Type | [CMLS](https://www.gsa.gov/about-us/organization/federal-acquisition-service/customer-and-stakeholder-engagement/centralized-mailing-list-service-cmls) Publication Number
 -- | -- | -- | -- | --
-[Helpful Hints for Purchase Account Use](/files/purchase-account-helpful-hints.pdf) | Card-sized brochure provides do’s and don'ts for purchase account holders. | Account Holders | PDF | 05-21-00960
+[Helpful Hints for Purchase Account Use](/files/purchase-account-helpful-hints.pdf) | Card-sized brochure provides dos and don'ts for purchase account holders. | Account Holders | PDF | 05-21-00960
 [Managing Your GSA SmartPay® Purchase Program](/files/managing-gsa-smartpay-purchase.pdf) | A government-wide guidebook for managers of the GSA SmartPay purchase program. | A/OPCs | PDF | 05-20-00209
 [Pre-Approval/Approval Request Template](/files/pre-approval-request.docx) | Purchase account holders can use this sample, non-mandatory template to send pre-approval or approval requests to their approving official for supplies/services that need to be purchased using a government purchase card. | Account Holders | Word | N/A
 [Pre-Approval Response Template](/files/pre-approval-response.docx) | Approving Officials can use this sample, non-mandatory template to send notice of pre-approval or denial of requests made by purchase account holders. | Approving Officials | Word | N/A


### PR DESCRIPTION
- We edited `do's and don'ts` to the grammatically correct `dos and don'ts` on the fleet publications page, but missed it here.
- This PR edits `do's` to `dos` because `do` is plural in this context (but not a contraction nor possessive)