### PR TITLE
Call function to get object of redirect urls

### DIFF
--- a/src/config/sitemapFilter.js
+++ b/src/config/sitemapFilter.js
@@ -5,7 +5,7 @@
 import redirects from "./redirects"
 
 export default (page) => {
-  return !Object.keys(redirects).some(fromPath => {
+  return !Object.keys(redirects()).some(fromPath => {
     // Remove trailing slashes before comparing
     page = page.replace(/\/$/, "")
     fromPath = fromPath.replace(/\/$/, "")


### PR DESCRIPTION
The default from "./redirects" is a function. Call it to get the object used in the comparison. 