### PR TITLE
Removes unused front matter

### DIFF
--- a/src/content/state-taxes/alabama.md
+++ b/src/content/state-taxes/alabama.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.revenue.alabama.gov/
   name: Alabama Department of Revenue
   phone: 334-242-1490
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/alaska.md
+++ b/src/content/state-taxes/alaska.md
@@ -4,7 +4,6 @@ contact:
   link: https://dor.alaska.gov/
   name: Alaska Department of Revenue
   phone: 907-269-6620
-exceptionsApply: true
 summary:
 - icon: highlight_off
   text: The state <b>does not</b> have a sales tax.

--- a/src/content/state-taxes/american-samoa.md
+++ b/src/content/state-taxes/american-samoa.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.americansamoa.gov/tax-office
   name: American Samoa Tax Office - Department of the Treasury
   phone: 1-684-633-4116
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/arizona.md
+++ b/src/content/state-taxes/arizona.md
@@ -4,7 +4,6 @@ contact:
   link: https://azdor.gov/
   name: Arizona Department of Revenue
   phone: 602-255-3381
-exceptionsApply: true
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state use tax.

--- a/src/content/state-taxes/arkansas.md
+++ b/src/content/state-taxes/arkansas.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.dfa.arkansas.gov/
   name: Arkansas Department of Finance and Administration
   phone: 501-682-7104
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/california.md
+++ b/src/content/state-taxes/california.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.cdtfa.ca.gov/taxes-and-fees/sutprograms.htm
   name: California Department of Tax and Fee Administration
   phone: 800-400-7115
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/colorado.md
+++ b/src/content/state-taxes/colorado.md
@@ -4,7 +4,6 @@ contact:
   link: https://cdor.colorado.gov
   name: Colorado Department of Revenue
   phone: 303-238-7378
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/connecticut.md
+++ b/src/content/state-taxes/connecticut.md
@@ -4,7 +4,6 @@ contact:
   link: https://portal.ct.gov/DRS/
   name: Connecticut Department of Revenue
   phone: 860-297-5962
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/delaware.md
+++ b/src/content/state-taxes/delaware.md
@@ -4,7 +4,6 @@ contact:
   link: https://revenue.delaware.gov
   name: Delaware Division of Revenue
   phone: 302-577-8205
-exceptionsApply: true
 summary:
 - icon: error_outline
   text: The state <b>does not</b> have a sales tax; instead it imposes an occupancy

--- a/src/content/state-taxes/district-of-columbia.md
+++ b/src/content/state-taxes/district-of-columbia.md
@@ -4,7 +4,6 @@ contact:
   link: https://otr.cfo.dc.gov/
   name: DC Office of Tax and Revenue
   phone: 202-727-4829
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/florida.md
+++ b/src/content/state-taxes/florida.md
@@ -4,7 +4,6 @@ contact:
   link: https://floridarevenue.com/
   name: Florida Department of Revenue
   phone: 850-488-6800
-exceptionsApply: false
 summary:
 - icon: check_circle_outline
   text: Individually billed accounts (IBA) <b>are</b> exempt from state sales

--- a/src/content/state-taxes/georgia.md
+++ b/src/content/state-taxes/georgia.md
@@ -4,7 +4,6 @@ contact:
   link: https://dor.georgia.gov/
   name: Georgia Department of Revenue
   phone: 404-417-6649
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/guam.md
+++ b/src/content/state-taxes/guam.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.guamtax.com/
   name: Guam Department of Revenue and Taxation
   phone: 671-635-1835
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/hawaii.md
+++ b/src/content/state-taxes/hawaii.md
@@ -4,7 +4,6 @@ contact:
   link: https://tax.hawaii.gov/
   name: Hawaii Department of Taxation
   phone: 808-587-1577
-exceptionsApply: true
 summary:
 - icon: error_outline
   text: The state <b>does not</b> have a sales tax; instead it assesses a General

--- a/src/content/state-taxes/idaho.md
+++ b/src/content/state-taxes/idaho.md
@@ -4,7 +4,6 @@ contact:
   link: https://tax.idaho.gov/
   name: Idaho State Tax Commission
   phone: 800-972-7660
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/illinois.md
+++ b/src/content/state-taxes/illinois.md
@@ -4,7 +4,6 @@ contact:
   link: https://www2.illinois.gov/rev/Pages/default.aspx
   name: Illinois Department of Revenue
   phone: 800-732-8866
-exceptionsApply: true
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/indiana.md
+++ b/src/content/state-taxes/indiana.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.in.gov/dor/
   name: Indiana Department of Revenue
   phone: 317-232-2240
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/iowa.md
+++ b/src/content/state-taxes/iowa.md
@@ -4,7 +4,6 @@ contact:
   link: https://tax.iowa.gov/
   name: Iowa Department of Revenue
   phone: 515-281-3114
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/kansas.md
+++ b/src/content/state-taxes/kansas.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.ksrevenue.gov/
   name: Kansas Department of Revenue
   phone: 785-368-8222
-exceptionsApply: false
 summary:
 - icon: check_circle_outline
   text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.

--- a/src/content/state-taxes/kentucky.md
+++ b/src/content/state-taxes/kentucky.md
@@ -4,7 +4,6 @@ contact:
   link: https://revenue.ky.gov/
   name: Kentucky Department of Revenue
   phone: 502-564-4581​
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/louisiana.md
+++ b/src/content/state-taxes/louisiana.md
@@ -4,7 +4,6 @@ contact:
   link: https://revenue.louisiana.gov/
   name: Louisiana Department of Revenue
   phone: 225-219-7462
-exceptionsApply: false
 summary:
 - icon: check_circle_outline
   text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.

--- a/src/content/state-taxes/maine.md
+++ b/src/content/state-taxes/maine.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.maine.gov/portal/index.html
   name: Maine Department of Revenue
   phone: 207-624-9693
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/maryland.md
+++ b/src/content/state-taxes/maryland.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.marylandtaxes.gov/
   name: Comptroller of Maryland
   phone: 800-638-2937
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/massachusetts.md
+++ b/src/content/state-taxes/massachusetts.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.mass.gov/orgs/massachusetts-department-of-revenue
   name: Massachusetts Department of Revenue
   phone: 617-887-6367
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/michigan.md
+++ b/src/content/state-taxes/michigan.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.michigan.gov/treasury/
   name: Michigan Department of Treasury
   phone: 517-636-4357
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/minnesota.md
+++ b/src/content/state-taxes/minnesota.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.revenue.state.mn.us/
   name: Minnesota Department of Revenue
   phone: 800-657-3777 or 651-296-6181
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/mississippi.md
+++ b/src/content/state-taxes/mississippi.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.dor.ms.gov/
   name: Mississippi Department of Revenue
   phone: 601-923-7700
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/missouri.md
+++ b/src/content/state-taxes/missouri.md
@@ -4,7 +4,6 @@ contact:
   link: https://dor.mo.gov/
   name: Missouri Department of Revenue
   phone: 573-751-2836
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/montana.md
+++ b/src/content/state-taxes/montana.md
@@ -4,7 +4,6 @@ contact:
   link: https://mtrevenue.gov/
   name: Montana Department of Revenue
   phone: 866-859-2254 or 406-444-5828
-exceptionsApply: true
 summary:
 - icon: error_outline
   text: The state <b>does not</b> have a sales tax; instead it assesses a lodging

--- a/src/content/state-taxes/nebraska.md
+++ b/src/content/state-taxes/nebraska.md
@@ -4,7 +4,6 @@ contact:
   link: https://revenue.nebraska.gov/
   name: Nebraska Department of Revenue
   phone: 402-471-5729 or 800-742-7474
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/nevada.md
+++ b/src/content/state-taxes/nevada.md
@@ -4,7 +4,6 @@ contact:
   link: https://tax.nv.gov/
   name: Nevada Department of Revenue
   phone: 866-962-3707
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/new-hampshire.md
+++ b/src/content/state-taxes/new-hampshire.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.revenue.nh.gov/
   name: New Hampshire Department of Revenue
   phone: 603-230-5000
-exceptionsApply: true
 summary:
 - icon: error_outline
   text: The state <b>does not</b> have a sales tax, but assesses a meals and rental

--- a/src/content/state-taxes/new-jersey.md
+++ b/src/content/state-taxes/new-jersey.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.state.nj.us/treasury/
   name: New Jersey Department of Treasury
   phone: 609-826-4400 or 800-323-4400
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/new-mexico.md
+++ b/src/content/state-taxes/new-mexico.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.tax.newmexico.gov/
   name: New Mexico Taxation and Revenue Department
   phone: 866-285-2996
-exceptionsApply: true
 summary:
 - icon: error_outline
   text: The state <b>does not</b> have a sales tax; instead it assesses a gross receipts

--- a/src/content/state-taxes/new-york.md
+++ b/src/content/state-taxes/new-york.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.tax.ny.gov/
   name: New York Department of Taxation and Finance
   phone: 518-485-2889
-exceptionsApply: false
 summary:
 - icon: check_circle_outline
   text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.

--- a/src/content/state-taxes/north-carolina.md
+++ b/src/content/state-taxes/north-carolina.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.ncdor.gov/
   name: North Carolina Department of Revenue
   phone: 877-252-3052
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/north-dakota.md
+++ b/src/content/state-taxes/north-dakota.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.tax.nd.gov/
   name: North Dakota Office of the State Tax Commissioner
   phone: 701-328-1246
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/northern-mariana-islands.md
+++ b/src/content/state-taxes/northern-mariana-islands.md
@@ -4,7 +4,6 @@ contact:
   link: https://finance.gov.mp/revenue-taxation.php
   name: Division of Revenue and Taxation
   phone: 670-664-1040
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/ohio.md
+++ b/src/content/state-taxes/ohio.md
@@ -4,7 +4,6 @@ contact:
   link: https://tax.ohio.gov/
   name: Ohio Department of Taxation Business
   phone: 888-405-4039
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/oklahoma.md
+++ b/src/content/state-taxes/oklahoma.md
@@ -4,7 +4,6 @@ contact:
   link: https://oklahoma.gov/tax.html
   name: Oklahoma Tax Commission
   phone: 405-521-3160
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/oregon.md
+++ b/src/content/state-taxes/oregon.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.oregon.gov/dor/Pages/index.aspx
   name: Oregon Department of Revenue
   phone: 503-378-4988 or 800-356-4222
-exceptionsApply: true
 summary:
 - icon: error_outline
   text: The state <b>does not</b> have a sales tax; instead it assesses a transient

--- a/src/content/state-taxes/pennsylvania.md
+++ b/src/content/state-taxes/pennsylvania.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.revenue.pa.gov/Pages/default.aspx
   name: Pennsylvania Department of Revenue
   phone: 717-787-1064
-exceptionsApply: true
 summary:
 - icon: check_circle_outline
   text: Individually billed accounts (IBA) <b>are</b> exempt from hotel occupancy

--- a/src/content/state-taxes/puerto-rico.md
+++ b/src/content/state-taxes/puerto-rico.md
@@ -4,7 +4,6 @@ contact:
   link: https://hacienda.pr.gov/
   name: Puerto Rico Department of Treasury
   phone: 787-721-2020
-exceptionsApply: false
 summary:
 - icon: check_circle_outline
   text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.

--- a/src/content/state-taxes/rhode-island.md
+++ b/src/content/state-taxes/rhode-island.md
@@ -4,8 +4,6 @@ contact:
   link: https://tax.ri.gov/
   name: Division of Taxation
   phone: 1-401-574-8829
-
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/south-carolina.md
+++ b/src/content/state-taxes/south-carolina.md
@@ -4,7 +4,6 @@ contact:
   link: https://dor.sc.gov/
   name: South Carolina Department of Revenue
   phone: 844-898-8542
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/south-dakota.md
+++ b/src/content/state-taxes/south-dakota.md
@@ -4,7 +4,6 @@ contact:
   link: https://dor.sd.gov/
   name: South Dakota Department of Revenue
   phone: 800-829-9188
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/tennessee.md
+++ b/src/content/state-taxes/tennessee.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.tn.gov/revenue
   name: Tennessee Department of Revenue
   phone: 615-253-0600
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/texas.md
+++ b/src/content/state-taxes/texas.md
@@ -4,7 +4,6 @@ contact:
   link: https://comptroller.texas.gov/
   name: Texas Comptroller of Public Accounts
   phone: 800-252-5555
-exceptionsApply: false
 summary:
 - icon: check_circle_outline
   text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.

--- a/src/content/state-taxes/utah.md
+++ b/src/content/state-taxes/utah.md
@@ -4,7 +4,6 @@ contact:
   link: https://tax.utah.gov/
   name: Utah State Tax Commission
   phone: 801-297-2200 or 800-662-4335
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/vermont.md
+++ b/src/content/state-taxes/vermont.md
@@ -4,7 +4,6 @@ contact:
   link: https://tax.vermont.gov/
   name: Vermont Department of Taxation
   phone: 802-828-2551
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/virgin-islands.md
+++ b/src/content/state-taxes/virgin-islands.md
@@ -4,7 +4,6 @@ contact:
   link: https://bir.vi.gov/
   name: Virgin Islands Bureau of Internal Revenue
   phone: 340-715-1040
-exceptionsApply: false
 summary:
 - icon: check_circle_outline
   text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.

--- a/src/content/state-taxes/virginia.md
+++ b/src/content/state-taxes/virginia.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.tax.virginia.gov/
   name: Virginia Department of Taxation
   phone: 804-367-8037
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/washington.md
+++ b/src/content/state-taxes/washington.md
@@ -4,7 +4,6 @@ contact:
   link: https://dor.wa.gov/
   name: Department of Revenue Washington State
   phone: 360-705-6705
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/west-virginia.md
+++ b/src/content/state-taxes/west-virginia.md
@@ -4,7 +4,6 @@ contact:
   link: https://tax.wv.gov/Pages/default.aspx
   name: West Virginia State Tax Department
   phone: 800-982-8297
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales

--- a/src/content/state-taxes/wisconsin.md
+++ b/src/content/state-taxes/wisconsin.md
@@ -4,7 +4,6 @@ contact:
   link: https://www.revenue.wi.gov/
   name: Wisconsin Department of Revenue
   phone: 608-266-2776
-exceptionsApply: false
 summary:
 - icon: check_circle_outline
   text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.

--- a/src/content/state-taxes/wyoming.md
+++ b/src/content/state-taxes/wyoming.md
@@ -4,7 +4,6 @@ contact:
   link: https://revenue.wyo.gov/
   name: Wyoming Department of Revenue
   phone: 307-777-5275
-exceptionsApply: false
 summary:
 - icon: highlight_off
   text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales


### PR DESCRIPTION
- This removes unused `exceptionsApply` front matter key
- This key was contemplated in early designs, but the role of this key is now fulfilled by a check for `summary` information