### PR TITLE
Mmeyer/316 frontmatter markdown 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@astrojs/sitemap": "^1.3.3",
         "astro": "^2.9.7",
         "hast-util-select": "^5.0.5",
+        "marked": "^8.0.1",
+        "marked-smartypants": "^1.1.2",
         "unist-util-visit": "^4.1.2",
         "uuid": "^9.0.0"
       },
@@ -7947,6 +7949,28 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/marked": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-8.0.1.tgz",
+      "integrity": "sha512-eEbeEb/mJwh+sNLEhHOWtxMgjN/NEwZUBs1nkiIH2sTQTq07KmPMQ48ihyvo5+Ya56spVOPhunfGr6406crCVA==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/marked-smartypants": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/marked-smartypants/-/marked-smartypants-1.1.2.tgz",
+      "integrity": "sha512-DkQS/d8tlHb7fekmD1LYBp0heHsA/m/kKVoL9zY5xykY6tz7KSi5RHjoRtmZIJ24L+B5Ojlbzd6tDbu5Vqs8Qg==",
+      "dependencies": {
+        "smartypants": "^0.2.2"
+      },
+      "peerDependencies": {
+        "marked": ">=4 <9"
+      }
+    },
     "node_modules/matchdep": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
@@ -12124,6 +12148,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smartypants": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.2.2.tgz",
+      "integrity": "sha512-TzobUYoEft/xBtb2voRPryAUIvYguG0V7Tt3de79I1WfXgCwelqVsGuZSnu3GFGRZhXR90AeEYIM+icuB/S06Q==",
+      "bin": {
+        "smartypants": "bin/smartypants.js",
+        "smartypantsu": "bin/smartypantsu.js"
       }
     },
     "node_modules/snapdragon": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@astrojs/sitemap": "^1.3.3",
     "astro": "^2.9.7",
     "hast-util-select": "^5.0.5",
+    "marked": "^8.0.1",
+    "marked-smartypants": "^1.1.2",
     "unist-util-visit": "^4.1.2",
     "uuid": "^9.0.0"
   },

--- a/src/components/FullSizeTemplate.astro
+++ b/src/components/FullSizeTemplate.astro
@@ -1,5 +1,9 @@
 ---
 import TopNav from '@components/TopNav.astro'
+import { marked } from 'marked';
+import { markedSmartypants } from "marked-smartypants";
+marked.use(markedSmartypants());
+
 const { title, intro, parent_nav_path, parent_nav_text } = Astro.props;
 ---
 <!--
@@ -11,9 +15,7 @@ const { title, intro, parent_nav_path, parent_nav_text } = Astro.props;
     <main id="main-content" class="usa-prose ">
         <h1>{ title }</h1>
         { intro && ( 
-          <p class="usa-intro">
-            {intro}
-          </p>
+          <p class="usa-intro" set:html={ marked.parseInline(intro) } />
         )}
         <slot />
     </main>

--- a/src/components/StateTaxSummaryList.astro
+++ b/src/components/StateTaxSummaryList.astro
@@ -1,4 +1,8 @@
 ---
+import { marked } from 'marked';
+import { markedSmartypants } from "marked-smartypants";
+marked.use(markedSmartypants());
+
 const {items} = Astro.props;
 
 const icon_colors = {
@@ -19,7 +23,7 @@ const explains_iba_cba = items.some(({text}) => text.includes('(IBA)')) &&  item
             <use xlink:href={`${import.meta.env.BASE_URL}images/sprite.svg#${icon}`}></use>
           </svg>
         </div>
-        <div class="usa-icon-list__content" set:html={text} />
+        <div class="usa-icon-list__content" set:html={marked.parseInline(text)} />
       </li>
       ))}
     </ul>

--- a/src/content/how-it-works/index.mdx
+++ b/src/content/how-it-works/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: How GSA SmartPay® Works
-description: "The GSA SmartPay program is the world’s largest government charge card and commercial payment solutions program."
+description: "The GSA SmartPay program is the world's largest government charge card and commercial payment solutions program."
+intro: Through the [GSA SmartPay 3 Master Contract](/about/master-contract), the GSA SmartPay program provides agencies/organizations with a comprehensive portfolio of purchase, travel, fleet and integrated payment solutions to support mission needs.
 slug: "./"
 order: 0
 category: how it works
@@ -8,8 +9,6 @@ tags:
   - banks
   - master contract
 ---
-
-<p class="usa-intro">Through the [GSA SmartPay 3 Master Contract](/about/master-contract), the GSA SmartPay program provides agencies/organizations with a comprehensive portfolio of purchase, travel, fleet and integrated payment solutions to support mission needs.</p>
 
 Agencies/organizations issue a task order under the GSA SmartPay 3 Master Contract to one of the GSA SmartPay contractor banks, Citibank or U.S. Bank. Then, the awarded bank provides payment solutions to the agency.
 

--- a/src/content/merchants/index.md
+++ b/src/content/merchants/index.md
@@ -1,7 +1,7 @@
 ---
 title: Merchants
 description: "Information about the GSA SmartPay program for merchants, vendors, and businesses."
-intro: "The GSA SmartPay® program provides payment solutions to the federal government for conducting official business."
+intro: "The GSA SmartPay® program provide's payment solutions to the federal government for conducting official business."
 slug: "./"
 order: 0
 category: merchants

--- a/src/content/merchants/index.md
+++ b/src/content/merchants/index.md
@@ -1,7 +1,7 @@
 ---
 title: Merchants
 description: "Information about the GSA SmartPay program for merchants, vendors, and businesses."
-intro: "The GSA SmartPay® program provide's payment solutions to the federal government for conducting official business."
+intro: "The GSA SmartPay® program provides payment solutions to the federal government for conducting official business."
 slug: "./"
 order: 0
 category: merchants

--- a/src/content/state-taxes/alabama.md
+++ b/src/content/state-taxes/alabama.md
@@ -6,10 +6,10 @@ contact:
   phone: 334-242-1490
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/alaska.md
+++ b/src/content/state-taxes/alaska.md
@@ -6,7 +6,7 @@ contact:
   phone: 907-269-6620
 summary:
 - icon: highlight_off
-  text: The state <b>does not</b> have a sales tax.
+  text: The state **does not** have a sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/american-samoa.md
+++ b/src/content/state-taxes/american-samoa.md
@@ -6,10 +6,10 @@ contact:
   phone: 1-684-633-4116
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/arizona.md
+++ b/src/content/state-taxes/arizona.md
@@ -6,13 +6,13 @@ contact:
   phone: 602-255-3381
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state use tax.
+  text: Individually billed accounts (IBA) **are not** exempt from state use tax.
 - icon: highlight_off
-  text: IBAs <b>are not</b> exempt from transaction privilege tax.
+  text: IBAs **are not** exempt from transaction privilege tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state use tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state use tax.
 - icon: error_outline
-  text: CBAs <b>may not be</b> exempt from transaction privilege tax.
+  text: CBAs **may not be** exempt from transaction privilege tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/arkansas.md
+++ b/src/content/state-taxes/arkansas.md
@@ -6,10 +6,10 @@ contact:
   phone: 501-682-7104
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/california.md
+++ b/src/content/state-taxes/california.md
@@ -6,10 +6,10 @@ contact:
   phone: 800-400-7115
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/colorado.md
+++ b/src/content/state-taxes/colorado.md
@@ -6,10 +6,10 @@ contact:
   phone: 303-238-7378
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/connecticut.md
+++ b/src/content/state-taxes/connecticut.md
@@ -6,10 +6,10 @@ contact:
   phone: 860-297-5962
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/delaware.md
+++ b/src/content/state-taxes/delaware.md
@@ -6,10 +6,10 @@ contact:
   phone: 302-577-8205
 summary:
 - icon: error_outline
-  text: The state <b>does not</b> have a sales tax; instead it imposes an occupancy
+  text: The state **does not** have a sales tax; instead it imposes an occupancy
     tax for hotel stay.
 - icon: check_circle_outline
-  text: The federal government <b>is</b> exempt from occupancy tax.
+  text: The federal government **is** exempt from occupancy tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/district-of-columbia.md
+++ b/src/content/state-taxes/district-of-columbia.md
@@ -6,10 +6,10 @@ contact:
   phone: 202-727-4829
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/florida.md
+++ b/src/content/state-taxes/florida.md
@@ -6,10 +6,10 @@ contact:
   phone: 850-488-6800
 summary:
 - icon: check_circle_outline
-  text: Individually billed accounts (IBA) <b>are</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/georgia.md
+++ b/src/content/state-taxes/georgia.md
@@ -6,10 +6,10 @@ contact:
   phone: 404-417-6649
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/guam.md
+++ b/src/content/state-taxes/guam.md
@@ -6,10 +6,10 @@ contact:
   phone: 671-635-1835
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/hawaii.md
+++ b/src/content/state-taxes/hawaii.md
@@ -6,12 +6,12 @@ contact:
   phone: 808-587-1577
 summary:
 - icon: error_outline
-  text: The state <b>does not</b> have a sales tax; instead it assesses a General
+  text: The state **does not** have a sales tax; instead it assesses a General
     Excise Tax (GET) and a Transient Accomodation Tax (TAT) on merchants.
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from GET or TAT.
+  text: Individually billed accounts (IBA) **are not** exempt from GET or TAT.
 - icon: error_outline
-  text: Centrally billed accounts (CBA) <b>may be</b> exempt from GET.
+  text: Centrally billed accounts (CBA) **may be** exempt from GET.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/idaho.md
+++ b/src/content/state-taxes/idaho.md
@@ -6,10 +6,10 @@ contact:
   phone: 800-972-7660
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/illinois.md
+++ b/src/content/state-taxes/illinois.md
@@ -6,10 +6,10 @@ contact:
   phone: 800-732-8866
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/indiana.md
+++ b/src/content/state-taxes/indiana.md
@@ -6,10 +6,10 @@ contact:
   phone: 317-232-2240
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/iowa.md
+++ b/src/content/state-taxes/iowa.md
@@ -6,10 +6,10 @@ contact:
   phone: 515-281-3114
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/kansas.md
+++ b/src/content/state-taxes/kansas.md
@@ -6,11 +6,11 @@ contact:
   phone: 785-368-8222
 summary:
 - icon: check_circle_outline
-  text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.
+  text: Individually billed accounts (IBA) **are** exempt from state sales tax.
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from transient guest tax.
+  text: Individually billed accounts (IBA) **are not** exempt from transient guest tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/kentucky.md
+++ b/src/content/state-taxes/kentucky.md
@@ -6,10 +6,10 @@ contact:
   phone: 502-564-4581​
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/louisiana.md
+++ b/src/content/state-taxes/louisiana.md
@@ -6,9 +6,9 @@ contact:
   phone: 225-219-7462
 summary:
 - icon: check_circle_outline
-  text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.
+  text: Individually billed accounts (IBA) **are** exempt from state sales tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/maine.md
+++ b/src/content/state-taxes/maine.md
@@ -6,10 +6,10 @@ contact:
   phone: 207-624-9693
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/maryland.md
+++ b/src/content/state-taxes/maryland.md
@@ -6,10 +6,10 @@ contact:
   phone: 800-638-2937
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 ## Forms

--- a/src/content/state-taxes/massachusetts.md
+++ b/src/content/state-taxes/massachusetts.md
@@ -6,12 +6,12 @@ contact:
   phone: 617-887-6367
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: error_outline
-  text: IBAs <b>may be</b> exempt from occupancy excise tax.
+  text: IBAs **may be** exempt from occupancy excise tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/michigan.md
+++ b/src/content/state-taxes/michigan.md
@@ -6,10 +6,10 @@ contact:
   phone: 517-636-4357
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/minnesota.md
+++ b/src/content/state-taxes/minnesota.md
@@ -6,10 +6,10 @@ contact:
   phone: 800-657-3777 or 651-296-6181
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/mississippi.md
+++ b/src/content/state-taxes/mississippi.md
@@ -6,10 +6,10 @@ contact:
   phone: 601-923-7700
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/missouri.md
+++ b/src/content/state-taxes/missouri.md
@@ -6,10 +6,10 @@ contact:
   phone: 573-751-2836
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/montana.md
+++ b/src/content/state-taxes/montana.md
@@ -6,12 +6,12 @@ contact:
   phone: 866-859-2254 or 406-444-5828
 summary:
 - icon: error_outline
-  text: The state <b>does not</b> have a sales tax; instead it assesses a lodging
+  text: The state **does not** have a sales tax; instead it assesses a lodging
     sales tax for hotel stay.
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from the lodging sales tax.
+  text: Individually billed accounts (IBA) **are not** exempt from the lodging sales tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from the lodging sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from the lodging sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/nebraska.md
+++ b/src/content/state-taxes/nebraska.md
@@ -6,10 +6,10 @@ contact:
   phone: 402-471-5729 or 800-742-7474
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/nevada.md
+++ b/src/content/state-taxes/nevada.md
@@ -6,10 +6,10 @@ contact:
   phone: 866-962-3707
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/new-hampshire.md
+++ b/src/content/state-taxes/new-hampshire.md
@@ -6,13 +6,13 @@ contact:
   phone: 603-230-5000
 summary:
 - icon: error_outline
-  text: The state <b>does not</b> have a sales tax, but assesses a meals and rental
+  text: The state **does not** have a sales tax, but assesses a meals and rental
     tax for hotel stay.
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from the meals and
+  text: Individually billed accounts (IBA) **are not** exempt from the meals and
     rental tax.
 - icon: check_circle_outline
-  text: Centrally Billed Accounts (CBA) <b>are</b> exempt from the meals and rental tax.
+  text: Centrally Billed Accounts (CBA) **are** exempt from the meals and rental tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/new-jersey.md
+++ b/src/content/state-taxes/new-jersey.md
@@ -6,10 +6,10 @@ contact:
   phone: 609-826-4400 or 800-323-4400
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/new-mexico.md
+++ b/src/content/state-taxes/new-mexico.md
@@ -6,13 +6,13 @@ contact:
   phone: 866-285-2996
 summary:
 - icon: error_outline
-  text: The state <b>does not</b> have a sales tax; instead it assesses a gross receipts
+  text: The state **does not** have a sales tax; instead it assesses a gross receipts
     tax on merchants.
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from the gross receipts
+  text: Individually billed accounts (IBA) **are not** exempt from the gross receipts
     tax.
 - icon: error_outline
-  text: Centrally billed accounts (CBA) <b>may be</b> exempt from the gross receipts
+  text: Centrally billed accounts (CBA) **may be** exempt from the gross receipts
     tax.
 updated: 2023-02-15
 ---

--- a/src/content/state-taxes/new-york.md
+++ b/src/content/state-taxes/new-york.md
@@ -6,9 +6,9 @@ contact:
   phone: 518-485-2889
 summary:
 - icon: check_circle_outline
-  text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.
+  text: Individually billed accounts (IBA) **are** exempt from state sales tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/north-carolina.md
+++ b/src/content/state-taxes/north-carolina.md
@@ -6,10 +6,10 @@ contact:
   phone: 877-252-3052
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/north-dakota.md
+++ b/src/content/state-taxes/north-dakota.md
@@ -6,10 +6,10 @@ contact:
   phone: 701-328-1246
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-07-24
 ---
 

--- a/src/content/state-taxes/northern-mariana-islands.md
+++ b/src/content/state-taxes/northern-mariana-islands.md
@@ -6,10 +6,10 @@ contact:
   phone: 670-664-1040
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/ohio.md
+++ b/src/content/state-taxes/ohio.md
@@ -6,10 +6,10 @@ contact:
   phone: 888-405-4039
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/oklahoma.md
+++ b/src/content/state-taxes/oklahoma.md
@@ -6,10 +6,10 @@ contact:
   phone: 405-521-3160
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/oregon.md
+++ b/src/content/state-taxes/oregon.md
@@ -6,13 +6,13 @@ contact:
   phone: 503-378-4988 or 800-356-4222
 summary:
 - icon: error_outline
-  text: The state <b>does not</b> have a sales tax; instead it assesses a transient
+  text: The state **does not** have a sales tax; instead it assesses a transient
     lodging tax for hotel stay.
 - icon: check_circle_outline
-  text: Individually billed accounts (IBA) <b>are</b> exempt from the transient lodging
+  text: Individually billed accounts (IBA) **are** exempt from the transient lodging
     tax.
 - icon: check_circle_outline
-  text: Centrally Billed Accounts (CBA) <b>are</b> exempt from the transient lodging tax.
+  text: Centrally Billed Accounts (CBA) **are** exempt from the transient lodging tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/pennsylvania.md
+++ b/src/content/state-taxes/pennsylvania.md
@@ -6,10 +6,10 @@ contact:
   phone: 717-787-1064
 summary:
 - icon: check_circle_outline
-  text: Individually billed accounts (IBA) <b>are</b> exempt from hotel occupancy
+  text: Individually billed accounts (IBA) **are** exempt from hotel occupancy
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/puerto-rico.md
+++ b/src/content/state-taxes/puerto-rico.md
@@ -6,9 +6,9 @@ contact:
   phone: 787-721-2020
 summary:
 - icon: check_circle_outline
-  text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.
+  text: Individually billed accounts (IBA) **are** exempt from state sales tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/rhode-island.md
+++ b/src/content/state-taxes/rhode-island.md
@@ -6,10 +6,10 @@ contact:
   phone: 1-401-574-8829
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-04-11
 ---
 

--- a/src/content/state-taxes/south-carolina.md
+++ b/src/content/state-taxes/south-carolina.md
@@ -6,10 +6,10 @@ contact:
   phone: 844-898-8542
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/south-dakota.md
+++ b/src/content/state-taxes/south-dakota.md
@@ -6,10 +6,10 @@ contact:
   phone: 800-829-9188
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/tennessee.md
+++ b/src/content/state-taxes/tennessee.md
@@ -6,10 +6,10 @@ contact:
   phone: 615-253-0600
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/texas.md
+++ b/src/content/state-taxes/texas.md
@@ -6,9 +6,9 @@ contact:
   phone: 800-252-5555
 summary:
 - icon: check_circle_outline
-  text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.
+  text: Individually billed accounts (IBA) **are** exempt from state sales tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/utah.md
+++ b/src/content/state-taxes/utah.md
@@ -6,10 +6,10 @@ contact:
   phone: 801-297-2200 or 800-662-4335
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/vermont.md
+++ b/src/content/state-taxes/vermont.md
@@ -6,10 +6,10 @@ contact:
   phone: 802-828-2551
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/virgin-islands.md
+++ b/src/content/state-taxes/virgin-islands.md
@@ -6,9 +6,9 @@ contact:
   phone: 340-715-1040
 summary:
 - icon: check_circle_outline
-  text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.
+  text: Individually billed accounts (IBA) **are** exempt from state sales tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/virginia.md
+++ b/src/content/state-taxes/virginia.md
@@ -6,10 +6,10 @@ contact:
   phone: 804-367-8037
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/washington.md
+++ b/src/content/state-taxes/washington.md
@@ -6,10 +6,10 @@ contact:
   phone: 360-705-6705
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/west-virginia.md
+++ b/src/content/state-taxes/west-virginia.md
@@ -6,10 +6,10 @@ contact:
   phone: 800-982-8297
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/wisconsin.md
+++ b/src/content/state-taxes/wisconsin.md
@@ -6,9 +6,9 @@ contact:
   phone: 608-266-2776
 summary:
 - icon: check_circle_outline
-  text: Individually billed accounts (IBA) <b>are</b> exempt from state sales tax.
+  text: Individually billed accounts (IBA) **are** exempt from state sales tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/content/state-taxes/wyoming.md
+++ b/src/content/state-taxes/wyoming.md
@@ -6,10 +6,10 @@ contact:
   phone: 307-777-5275
 summary:
 - icon: highlight_off
-  text: Individually billed accounts (IBA) <b>are not</b> exempt from state sales
+  text: Individually billed accounts (IBA) **are not** exempt from state sales
     tax.
 - icon: check_circle_outline
-  text: Centrally billed accounts (CBA) <b>are</b> exempt from state sales tax.
+  text: Centrally billed accounts (CBA) **are** exempt from state sales tax.
 updated: 2023-02-15
 ---
 

--- a/src/layouts/PageContentLayout.astro
+++ b/src/layouts/PageContentLayout.astro
@@ -13,4 +13,4 @@ marked.use(markedSmartypants());
     )}
 
     <slot />
-  </main>
+</main>

--- a/src/layouts/PageContentLayout.astro
+++ b/src/layouts/PageContentLayout.astro
@@ -1,0 +1,16 @@
+---
+/* Used as a wrapper for content pages that have a side navigation (most of the pages on the site) */
+const { title, intro } = Astro.props;
+import { marked } from 'marked';
+import { markedSmartypants } from "marked-smartypants";
+marked.use(markedSmartypants());
+---
+<main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
+    <h1>{ title }</h1>
+
+    { intro && ( 
+      <p class="usa-intro" set:html={ marked.parseInline(intro) } />
+    )}
+
+    <slot />
+  </main>

--- a/src/pages/about/[...slug].astro
+++ b/src/pages/about/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
+import PageContentLayout from '@layouts/PageContentLayout.astro';
 import SideNav from '@components/SideNav.astro'
 
 import { getCollection } from 'astro:content';
@@ -26,16 +27,11 @@ const { Content, headings } = await entry.render();
     headings={headings}
     id={entry.id}
   />
-  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
-    <h1>{ entry.data.title }</h1>
-
-    { entry.data.intro && ( 
-      <p class="usa-intro">
-        { entry.data.intro }
-      </p>
-    )}
-
+  <PageContentLayout
+    title={entry.data.title}
+    intro={entry.data.intro}
+  >
     <Content />
-    </main>
+  </PageContentLayout>
 </PageLayout>
     

--- a/src/pages/contact/[...slug].astro
+++ b/src/pages/contact/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
+import PageContentLayout from '@layouts/PageContentLayout.astro';
 import SideNav from '@components/SideNav.astro';
 import { getCollection } from 'astro:content';
 
@@ -24,16 +25,11 @@ const { Content, headings } = await entry.render();
       headings={headings}
       id={entry.id}
     />
-  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
-    <h1>{ entry.data.title }</h1>
-
-    { entry.data.intro && ( 
-      <p class="usa-intro">
-        { entry.data.intro }
-      </p>
-    )}
-
+  <PageContentLayout
+    title={entry.data.title}
+    intro={entry.data.intro}
+  >
     <Content />
-    </main>
+  </PageContentLayout>
 </PageLayout>
     

--- a/src/pages/how-it-works/[...slug].astro
+++ b/src/pages/how-it-works/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
+import PageContentLayout from '@layouts/PageContentLayout.astro';
 import SideNav from '@components/SideNav.astro'
 
 import { getCollection } from 'astro:content';
@@ -26,16 +27,11 @@ const { Content, headings } = await entry.render();
     headings={headings}
     id={entry.id}
   />
-  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
-    <h1>{ entry.data.title }</h1>
-
-    { entry.data.intro && ( 
-      <p class="usa-intro">
-        { entry.data.intro }
-      </p>
-    )}
-
+  <PageContentLayout
+    title={entry.data.title}
+    intro={entry.data.intro}
+  >
     <Content />
-  </main>
+  </PageContentLayout>
 </PageLayout>
     

--- a/src/pages/merchants/[...slug].astro
+++ b/src/pages/merchants/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
+import PageContentLayout from '@layouts/PageContentLayout.astro';
 import SideNav from '@components/SideNav.astro'
 
 import { getCollection } from 'astro:content';
@@ -36,16 +37,11 @@ const { Content } = await entry.render();
     pages={navigation_items}
     id={entry.id}
   />
-  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
-    <h1>{ entry.data.title }</h1>
-
-    { entry.data.intro && ( 
-      <p class="usa-intro">
-        { entry.data.intro }
-      </p>
-    )}
-
+  <PageContentLayout
+    title={entry.data.title}
+    intro={entry.data.intro}
+  >
     <Content />
-    </main>
+  </PageContentLayout>
 </PageLayout>
     

--- a/src/pages/policies-and-audits/[...slug].astro
+++ b/src/pages/policies-and-audits/[...slug].astro
@@ -5,6 +5,7 @@ It includs landing page (/policies-and-audits/), Policies page (/policies-and-au
 Page use side nav or use full size template based on frontmatter full_size_template value is provided or not. 
 */
 import PageLayout from '@layouts/PageLayout.astro';
+import PageContentLayout from '@layouts/PageContentLayout.astro';
 import SideNav from '@components/SideNav.astro'
 import FullSizeTemplate from '@components/FullSizeTemplate.astro'
 import { getCollection, getEntry } from 'astro:content';
@@ -27,34 +28,32 @@ const parent_path ="policies-and-audits/"
 ---
 
 <PageLayout title={entry.data.title}>
-  {entry.data.full_size_template? 
-  <FullSizeTemplate 
-  title={ entry.data.title }
-  parent_nav_path="policies-and-audits" 
-  parent_nav_text = "Return to the Policies & Audits" 
-  intro ={entry.data.intro}
-  >
-  <Content />
- </FullSizeTemplate>
-: 
-<SideNav 
-    title="Policies & Audits"
-    parent_path={parent_path}
-    pages={[...entries, smartbulletinsData]}
-    headings={headings}
-    id={entry.id}
-  />  
-  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs"> 
-    <h1>{ entry.data.title }</h1>
-
-    { entry.data.intro && ( 
-      <p class="usa-intro">
-        { entry.data.intro }
-      </p>
-    )}
-
-    <Content />
-  </main>
+  {entry.data.full_size_template
+  ? (
+    <FullSizeTemplate 
+      title={ entry.data.title }
+      parent_nav_path="policies-and-audits" 
+      parent_nav_text = "Return to the Policies & Audits" 
+      intro ={entry.data.intro}
+    >
+      <Content />
+    </FullSizeTemplate>
+    )
+  : (
+    <SideNav 
+      title="Policies & Audits"
+      parent_path={parent_path}
+      pages={[...entries, smartbulletinsData]}
+      headings={headings}
+      id={entry.id}
+    />  
+    <PageContentLayout
+      title={entry.data.title}
+      intro={entry.data.intro}
+    >
+      <Content />
+  </PageContentLayout>
+  )
 }
 </PageLayout>
     

--- a/src/pages/resources/[...slug].astro
+++ b/src/pages/resources/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
+import PageContentLayout from '@layouts/PageContentLayout.astro';
 import SideNav from '@components/SideNav.astro'
 
 import { getCollection } from 'astro:content';
@@ -25,15 +26,11 @@ const { Content, headings } = await entry.render();
     headings={headings}
     id={entry.id}
   />
-  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
-    <h1>{ entry.data.title }</h1>
-
-    { entry.data.intro && ( 
-      <p class="usa-intro">
-        { entry.data.intro }
-      </p>
-    )}
+  <PageContentLayout
+    title={entry.data.title}
+    intro={entry.data.intro}
+  >
     <Content />
-  </main>
+  </PageContentLayout>
 </PageLayout>
     

--- a/src/pages/resources/publications/[...slug].astro
+++ b/src/pages/resources/publications/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import PageLayout from '@layouts/PageLayout.astro';
+import PageContentLayout from '@layouts/PageContentLayout.astro';
 import TopNav from '@components/TopNav.astro';
 export async function getStaticPaths() {
   const entries = await getCollection('publications');
@@ -16,9 +17,10 @@ const { Content} = await entry.render();
 ---
 <PageLayout title ={entry.data.title} description={entry.data.description}>
   <TopNav parent_nav_path="resources/publications" parent_nav_text = "Return to the Publications and Videos" />
-  <main id="main-content" class="usa-layout-docs__main usa-prose usa-layout-docs">
-    <h1>{entry.data.title}</h1>
-    <p class="usa-intro">{entry.data.intro}</p>
+  <PageContentLayout
+    title={entry.data.title}
+    intro={entry.data.intro}
+  >
     <Content />
-  </main>
+  </PageContentLayout>
 </PageLayout>

--- a/src/pages/smarttax/[...slug].astro
+++ b/src/pages/smarttax/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
+import PageContentLayout from '@layouts/PageContentLayout.astro';
 import SideNav from '@components/SideNav.astro'
 
 import { getCollection } from 'astro:content';
@@ -25,17 +26,12 @@ const { Content, headings } = await entry.render();
     headings={headings}
     id={entry.id}
   />
-  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
-    <h1>{ entry.data.title }</h1>
-
-    { entry.data.intro && ( 
-      <p class="usa-intro">
-        { entry.data.intro }
-      </p>
-    )}
-
+  <PageContentLayout
+    title={entry.data.title}
+    intro={entry.data.intro}
+  >
     <Content />
-  </main>
+  </PageContentLayout>
 </PageLayout>
 
 <style is:global>

--- a/src/pages/stakeholders/[...slug].astro
+++ b/src/pages/stakeholders/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
+import PageContentLayout from '@layouts/PageContentLayout.astro';
 import SideNav from '@components/SideNav.astro'
 
 import { getCollection } from 'astro:content';
@@ -26,16 +27,11 @@ const { Content, headings } = await entry.render();
     headings={headings}
     id={entry.id}
   />
-  <main id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose usa-layout-docs">
-    <h1>{ entry.data.title }</h1>
-
-    { entry.data.intro && ( 
-      <p class="usa-intro">
-        { entry.data.intro }
-      </p>
-    )}
-
+  <PageContentLayout
+    title={entry.data.title}
+    intro={entry.data.intro}
+  >
     <Content />
-  </main>
+  </PageContentLayout>
 </PageLayout>
     


### PR DESCRIPTION
- Adds the ability to parse markdown in .astro files, which allows us to use markdown in front-matter when appropriate. The [markdown library](https://marked.js.org/#specifications) also has the ability to convert things like straight quotes and dashed to the typographic characters.
- Refactors the a frequently-used pattern into a layout component to reduce duplicate code.
- Changes the inline html in the state-tax content to markdown
- Puts the intro text for `/how-it-works/` back in the front matter now that we can render the markdown link.