### PR TITLE
Lower cases 'state of' in relevant instances

### DIFF
--- a/src/content/faq/faq.mdx
+++ b/src/content/faq/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: Frequently Asked Questions
-description: Check out frequently asked questions about the GSA SmartPay program. Learn about State Tax, Program Coordinators, Merchants, Government Shutdown, and more.
+description: Review frequently asked questions about the GSA SmartPay program. Learn about state taxes, program coordinator responsibilities, merchants, government shutdowns, and more.
 order: 1
 ---
 import Accordion from '@components/Accordion.astro';

--- a/src/content/state-taxes/alaska.md
+++ b/src/content/state-taxes/alaska.md
@@ -26,7 +26,7 @@ Alaska imposes a separate excise tax on rental vehicles. Government employees ar
 
 #### Notes
 
-The State of Alaska does not have a sales tax. Municipal, county, and local governments have the ability to assess other taxes and may have separate tax exemption forms and requirements.
+The state of Alaska does not have a sales tax. Municipal, county, and local governments have the ability to assess other taxes and may have separate tax exemption forms and requirements.
 
 ## Point of Contact
 - [Alaska Department of Revenue](https://dor.alaska.gov/)

--- a/src/content/state-taxes/arizona.md
+++ b/src/content/state-taxes/arizona.md
@@ -24,11 +24,11 @@ updated: 2023-02-15
 
 #### Notes
 
-In addition to a state use tax assessed to the cardholder, the State of Arizona can also assess a transaction privilege tax on the merchant.
+In addition to a state use tax assessed to the cardholder, the state of Arizona can also assess a transaction privilege tax on the merchant.
 
 Notes for the transaction privilege tax:
 
-* All merchants doing business in the State of Arizona are subject to the transaction privilege tax.
+* All merchants doing business in the state of Arizona are subject to the transaction privilege tax.
 * Merchants doing business with the federal government, where a CBA is used in the transaction, can request an exemption from the transaction privilege tax.
 * The merchant is not required to process the exemption form.
 * Should the merchant choose not to request an exemption, the state allows the transaction privilege tax to be passed along from the merchant to the cardholder.

--- a/src/content/state-taxes/florida.md
+++ b/src/content/state-taxes/florida.md
@@ -19,7 +19,7 @@ updated: 2023-02-15
 
 #### Notes
 
-According to the State of Florida, a Certificate of Exemption is not required for federal government employees.
+According to the state of Florida, a Certificate of Exemption is not required for federal government employees.
 
 As a Certificate of Exemption is not required for federal government agencies or employees, federal government agencies or employees may not have a Certificate of Exemption.  However, the state does allow merchants to request a Certificate of Exemption for their records.  Should a merchant require a Certificate of Exemption, please see Florida Administrative Code Rule below for information and language about the Certificate of Exemption for federal government agencies and employees.
 

--- a/src/content/state-taxes/hawaii.md
+++ b/src/content/state-taxes/hawaii.md
@@ -21,7 +21,7 @@ updated: 2023-02-15
 
 #### Notes
 
-The State of Hawaii does not assess state sales tax on consumers.  Instead, the state assesses GET on businesses for the sale of goods.
+The state of Hawaii does not assess state sales tax on consumers.  Instead, the state assesses GET on businesses for the sale of goods.
 
 Notes for the GET:
 


### PR DESCRIPTION
Fixes #323 

- Re-cases `State of` to `state of` in relevant instances
- Minor edit to FAQ `meta` description
