### PR TITLE
Fixes path for og image meta tag

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,7 +20,7 @@ const { title, description } = Astro.props;
     <meta name="description" content={description} />
     <meta property="og:title" content={title} />
     <meta property="og:url" content={Astro.url} />
-    <meta property="og:image" content={`${Astro.site}images/smartpay_meta_og_images.jpg`} /> 
+    <meta property="og:image" content={`${Astro.site}images/smartpay_meta_og_image.jpg`} /> 
 
     <title>{title}</title>
 


### PR DESCRIPTION
- Fixes #352 
- Fixes typo in `meta` path for `og:image`