### PR TITLE
move the account used for search.gov

### DIFF
--- a/src/components/GSAHeader.astro
+++ b/src/components/GSAHeader.astro
@@ -37,7 +37,7 @@ import PrimaryMenu from '@components/PrimaryMenu.astro';
         </ul>
         <section aria-label="Search component">
           <form class="usa-search usa-search--small" role="search" action="https://search.usa.gov/search" accept-charset="UTF-8" method="get">
-            <input type="hidden" name="affiliate" id="affiliate" value="gsa_smartpay_demo" autocomplete="off" />
+            <input type="hidden" name="affiliate" id="affiliate" value="gsa_smartpay" autocomplete="off" />
             <label class="usa-sr-only" for="query">Search</label>
             <input
               class="usa-input"


### PR DESCRIPTION
There is an existing account for SmartPay on search.gov in addition to the one we used for the demo. Search.gov has told us we should be using this one if we do not want demo.smartpay.gov results.