### PR TITLE
Update 030.md

### DIFF
--- a/src/content/smart-bulletins/030.md
+++ b/src/content/smart-bulletins/030.md
@@ -32,7 +32,7 @@ The purpose of this GSA SmartPay Smart Bulletin is to provide agencies/organizat
 
 OMB memorandum M-17-26, dated June 25, 2017, discontinued agency/organization purchase and travel charge card statistical reporting to OMB. However, OMB in that memorandum also required agencies to maintain that statistical reporting information for their own use in the management of their charge card programs. It further designated GSA’s Center for Charge Card Management (CCCM) as the central repository for the agency charge card statistical data, which was previously required to be submitted to OMB. CCCM will post this statistical and narrative data on GSA Interact for agencies/organizations subject to the Chief Financial Officers’ (CFO) Act. CCCM may also post information pertaining to other GSA SmartPay participating agencies/organizations as well. CCCM will work with the GSA SmartPay contractor banks to obtain agency/organization statistical reporting data in an electronic, automated manner to the extent possible. The balance of the statistical data CCCM is unable to directly obtain from contractor banks will need to be provided by the CFO Act agencies/organizations (and other entities as required) to CCCM. CCCM will use a central repository for these reports. The Circular also states that CCCM “may issue further guidance on both narrative and statistical reporting through the GSA Smart Bulletin process.” This bulletin constitutes further guidance.
 
-### OMB Circular A-123, Appendix B Chapter 5.3.1 – Statistical Reporting –
+### OMB Circular A-123, Appendix B Chapter 5.3.1 – Statistical Reporting 
 The requested information in the template attached below shall be submitted, at a minimum, on an annual fiscal year basis. Agency-provided information shall be furnished to CCCM no later than 90 calendar days after the end of the Fiscal Year (FY). The due date for agency/organization submission of FY2019 agency statistical reporting to CCCM is hereby extended to No Later Than (NLT) February 28, 2020. This extension applies only to the FY 19 reports.
 
 The Statistical Reporting requirement applies to **all business lines** under the GSA SmartPay program. Agencies must report the following items for each business line:
@@ -63,7 +63,7 @@ Specific requirements for each business line are as follows:
 - Number of integrated cards with transaction limits over the micro-purchase threshold and;
 - Ratio of the number of confirmed violations reported pursuant to P.L. 112-194 as compared to the number of valid transactions within the reporting period (GSA’s Center for Charge Card Management will obtain confirmed violation information from OMB/OFFM).
 
-### OMB Circular A-123, Appendix B Chapter 5.3.2 – Narrative Reporting – 
+### OMB Circular A-123, Appendix B Chapter 5.3.2 – Narrative Reporting 
 For agencies/organizations subject to the CFO Act, the following information should be updated annually on a fiscal year basis and provided to CCCM *no later than 90 calendar days after the end of each fiscal year:*
 - The date(s) of most recent and next scheduled independent review(s) (e.g., OIG audits and risk assessments) for all agency charge card programs;
 - A description of the current process for monitoring delinquency, including what reports the agency reviews and what actions are taken when a problem is discovered;


### PR DESCRIPTION
removed training dashes from OMB Circular A-123, Appendix B Chapter 5.3.1 – Statistical Reporting – and OMB Circular A-123, Appendix B Chapter 5.3.2 – Narrative Reporting –